### PR TITLE
Enable clippy, update after redbpf API changes, add ubuntu and fedora CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,74 @@
-version: 2
+version: 2.1
+commands:
+  install_rust:
+    steps:
+      - run:
+          name: Install rust
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf -o rustup.sh https://sh.rustup.rs
+            chmod 755 rustup.sh
+            ./rustup.sh -y
+            . /root/.cargo/env
+            rustup target add x86_64-unknown-linux-musl
+            rustup component add rustfmt
+
 jobs:
-  pack:
+  ubuntu:
+    parameters:
+      version:
+        type: string
+        default: "latest"
+      kernel_version:
+        type: string
+        default: "$(uname -r)"
+    working_directory: /build
+    docker:
+      - image: ubuntu:<< parameters.version >>
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /build
+
+      - run:
+          name: Install deps
+          command: |
+            apt-get update
+            apt-get install -y curl clang llvm musl-tools capnproto libelf-dev linux-headers-<< parameters.kernel_version >> ca-certificates{,-java}
+
+      - install_rust
+
+      - run:
+          name: Build static binary
+          command: |
+            . /root/.cargo/env
+            cargo test --target=x86_64-unknown-linux-musl --release || exit 1
+            cargo build --target=x86_64-unknown-linux-musl --release || exit 1
+
+  fedora:
+    working_directory: /build
+    docker:
+      - image: fedora:29
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /build
+
+      - run:
+          name: Install deps
+          command: |
+            yum install -y clang llvm capnproto kernel-4.18.16-300.fc29.x86_64 kernel-devel-4.18.16-300.fc29.x86_64 elfutils-libelf-devel ca-certificates
+
+      - install_rust
+
+      - run:
+          name: Build
+          command: |
+            . /root/.cargo/env
+            export KERNEL_VERSION=4.18.16-300.fc29.x86_64
+            cargo test --release || exit 1
+            cargo build --release || exit 1
+
+  build_docker_image:
     environment:
       CONTAINER_NAME: "quay.io/redsift/ingraind"
 
@@ -36,9 +104,9 @@ jobs:
 
             echo "Total sizes"
             docker images $CONTAINER_NAME
-            docker push $CONTAINER_NAME 
+            docker push $CONTAINER_NAME
 
-  build:
+  build_docker_binary:
     working_directory: /build
     docker:
       - image: quay.io/redsift/ingraind-build:latest
@@ -69,14 +137,25 @@ jobs:
             - "target"
 
       - store_artifacts:
-          path: /build/target/x86_64-unknown-linux-musl/release/ingraind 
+          path: /build/target/x86_64-unknown-linux-musl/release/ingraind
           destination: ingraind
 
 workflows:
-  version: 2
-  build_pack:
+  build:
     jobs:
-      - build
-      - pack:
+      - ubuntu:
+          name: "ubuntu 18.04"
+          version: "18.04"
+      - ubuntu:
+          name: "ubuntu 16.04"
+          version: "16.04"
+      - fedora:
+          name: "fedora 29"
+      - build_docker_binary:
+          filters:
+            branches:
+              only:
+                - master
+      - build_docker_image:
           requires:
-            - build
+            - build_docker_binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,21 +115,11 @@ jobs:
       - attach_workspace:
           at: /build
 
-      - restore_cache:
-          keys:
-            - ingraind-cargo
-
       - run:
           name: Build static binary
           command: |
             cargo test --target=x86_64-unknown-linux-musl --release || exit 1
             cargo build --target=x86_64-unknown-linux-musl --release || exit 1
-
-      - save_cache:
-          key: ingraind-cargo
-          paths:
-            - "/usr/local/cargo"
-            - "/build/target/"
 
       - persist_to_workspace:
           root: "./"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [build-dependencies]
 failure = "0.1"
-redbpf = { version = "^0.2", features = ["build"] }
+redbpf = { version = "^0.3", features = ["build"] }
 
 [build-dependencies.capnpc]
 version = "^0.9.3"
@@ -26,7 +26,7 @@ lazy_static = "1.1.0"
 
 libc = "0.2"
 lazy-socket = "0.3"
-redbpf = "^0.2"
+redbpf = "^0.3"
 
 uuid = { version = "0.6", features = ["v4"] }
 serde = "^1.0"

--- a/src/aggregations/buffer.rs
+++ b/src/aggregations/buffer.rs
@@ -65,16 +65,12 @@ impl Handler<Flush> for Buffer {
     fn handle(&mut self, _: Flush, _ctx: &mut Context<Self>) -> Self::Result {
         let evs: Vec<Measurement> = {
             let mut buffer = self.0.lock().unwrap();
-            let evs = buffer.drain().map(|(_, v)| v).collect();
-
-            evs
+            buffer.drain().map(|(_, v)| v).collect()
         };
 
-        if evs.len() == 0 {
-            return;
+        if !evs.is_empty() {
+            ::actix::spawn(self.1.send(Message::List(evs)).map_err(|_| ()));
         }
-
-        ::actix::spawn(self.1.send(Message::List(evs)).map_err(|_| ()));
     }
 }
 

--- a/src/backends/statsd.rs
+++ b/src/backends/statsd.rs
@@ -28,8 +28,8 @@ impl Statsd {
             env::var("STATSD_PORT").expect("The STATSD_PORT environment variable has to be set!");
         let port = u16::from_str(&port).expect("STATSD_PORT has to be a valid port number");
 
-        let udp_sink = BufferedUdpMetricSink::from((host.as_str(), port), helper_socket).expect(
-            &format!("Invalid statsd server settings: {}:{}", host, port),
+        let udp_sink = BufferedUdpMetricSink::from((host.as_str(), port), helper_socket).unwrap_or_else(|_|
+            panic!("Invalid statsd server settings: {}:{}", host, port)
         );
         let queuing_sink = QueuingMetricSink::from(udp_sink);
         let client = StatsdClient::from_sink("ingraind.metrics", queuing_sink);
@@ -58,8 +58,8 @@ impl Handler<Message> for Statsd {
 
     fn handle(&mut self, msg: Message, _ctx: &mut Context<Self>) -> Self::Result {
         match msg {
-            Message::List(ref ms) => for mut m in ms {
-                self.count_with_tags(&mut m);
+            Message::List(ref ms) => for m in ms {
+                self.count_with_tags(&m);
             },
             Message::Single(ref m) => self.count_with_tags(m),
         }

--- a/src/grains/connection.rs
+++ b/src/grains/connection.rs
@@ -1,7 +1,4 @@
-#![allow(non_camel_case_types)]
-
 use std::net::Ipv4Addr;
-use std::ptr;
 
 use crate::grains::protocol::ip::to_ipv4;
 use crate::grains::*;

--- a/src/grains/dns.rs
+++ b/src/grains/dns.rs
@@ -1,10 +1,7 @@
-#![allow(non_camel_case_types)]
-
-use std::ptr;
-include!(concat!(env!("OUT_DIR"), "/dns.rs"));
-
 use crate::grains::protocol::ip::to_ipv4;
 use crate::grains::*;
+
+include!(concat!(env!("OUT_DIR"), "/dns.rs"));
 
 pub struct DNS(pub DnsConfig);
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/grains/ebpf.rs
+++ b/src/grains/ebpf.rs
@@ -110,7 +110,7 @@ where
     fn bind_perf(&mut self, backends: &[BackendHandler]) -> EventOutputs {
         let online_cpus = cpus::get_online().unwrap();
         let mut output: EventOutputs = vec![];
-        for ref mut m in self.module.maps.iter_mut().filter(|m| m.kind == 4) {
+        for m in self.module.maps.iter_mut().filter(|m| m.kind == 4) {
             for cpuid in online_cpus.iter() {
                 let pm = PerfMap::bind(m, -1, *cpuid, 16, -1, 0).unwrap();
                 output.push(Box::new(PerfHandler {

--- a/src/grains/mod.rs
+++ b/src/grains/mod.rs
@@ -22,7 +22,7 @@ pub use crate::metrics::kind::*;
 pub use crate::metrics::{Measurement, Tags, ToTags, Unit};
 pub use std::net::Ipv4Addr;
 
-use redbpf::{Map, Module, VoidPtr};
+use redbpf::{Map, Module};
 
 pub fn to_le(i: u16) -> u16 {
     (i >> 8) | (i << 8)

--- a/src/grains/perfhandler.rs
+++ b/src/grains/perfhandler.rs
@@ -33,9 +33,11 @@ impl EventHandler for PerfHandler {
                             sample.size as usize,
                         ))
                     };
-                    msg.and_then(|m| Some(send_to(&self.backends, m)));
+                    if let Some(msg) = msg {
+                        send_to(&self.backends, msg);
+                    }
                 }
-            }
+            };
         }
     }
 }

--- a/src/grains/sockethandler.rs
+++ b/src/grains/sockethandler.rs
@@ -29,12 +29,9 @@ impl EventHandler for SocketHandler {
                 return;
             }
 
-            let msg = match read {
-                0 => None,
-                _ => (self.callback)(&buf[..plen]),
-            };
-
-            msg.and_then(|msg| Some(send_to(&self.backends, msg)));
+            if let Some(msg) = (self.callback)(&buf[..plen]) {
+                send_to(&self.backends, msg);
+            }
         }
     }
 }

--- a/src/grains/syscalls.rs
+++ b/src/grains/syscalls.rs
@@ -1,5 +1,3 @@
-#![allow(non_camel_case_types)]
-
 use std::collections::HashMap;
 use std::fs;
 
@@ -78,7 +76,7 @@ fn parse_symbol_map(path: &str) -> Result<KSyms, Error> {
     let symmap = fs::read_to_string(path)?;
     Ok(symmap
         .lines()
-        .map(|l| l.splitn(4, " ").collect::<Vec<&str>>())
+        .map(|l| l.splitn(4, ' ').collect::<Vec<&str>>())
         .map(|tokens| (u64::from_str_radix(&tokens[0], 16).unwrap(), tokens[2].to_string()))
         .collect())
 }

--- a/src/grains/tls.rs
+++ b/src/grains/tls.rs
@@ -10,7 +10,7 @@ use rustls::internal::msgs::{
     handshake::HandshakePayload, handshake::HasServerExtensions, handshake::ServerHelloPayload,
     handshake::ServerNamePayload, message::Message as TLSMessage, message::MessagePayload,
 };
-use rustls::{CipherSuite, ProtocolVersion};
+use rustls::CipherSuite;
 
 use std::net::Ipv4Addr;
 
@@ -38,7 +38,6 @@ impl EBPFGrain<'static> for TLS {
 }
 
 fn tls_to_message(buf: &[u8]) -> Option<Message> {
-    let mut version = ProtocolVersion::Unknown(0x0000);
     let (handshake, version) = {
         let offset = tcp_payload_offset(buf);
         let mut packet = TLSMessage::read_bytes(&buf[offset..])?;
@@ -79,7 +78,7 @@ fn parse_clienthello(payload: ClientHelloPayload, mut tags: Tags) -> Option<Mess
             sni.iter()
                 .filter(|sni| sni.typ == ServerNameType::HostName)
                 .map(|sni| match &sni.payload {
-                    ServerNamePayload::HostName(dnsn) => format!("{}", AsRef::<str>::as_ref(&dnsn)),
+                    ServerNamePayload::HostName(dnsn) => AsRef::<str>::as_ref(dnsn).to_string(),
                     _ => unreachable!(),
                 })
                 .collect::<Vec<String>>()
@@ -144,8 +143,8 @@ fn parse_ips(buf: &[u8]) -> (String, String) {
 
 fn parse_tcp_ports(buf: &[u8]) -> (u16, u16) {
     let offs = ETH_HLEN + iph_len(buf);
-    let s: u16 = (buf[offs + 0] as u16) << 8 | buf[offs + 1] as u16;
-    let d: u16 = (buf[offs + 2] as u16) << 8 | buf[offs + 3] as u16;
+    let s: u16 = u16::from(buf[offs]) << 8 | u16::from(buf[offs + 1]);
+    let d: u16 = u16::from(buf[offs + 2]) << 8 | u16::from(buf[offs + 3]);
 
     (d, s)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::all))]
+#![deny(clippy::all)]
 
 #[macro_use]
 extern crate actix;
@@ -23,6 +23,8 @@ use backends::Message;
 
 #[cfg(feature = "capnp-encoding")]
 mod ingraind_capnp {
+    #![allow(clippy::all)]
+    #![allow(dead_code)]
     include!(concat!(env!("OUT_DIR"), "/schema/ingraind_capnp.rs"));
 }
 
@@ -62,7 +64,7 @@ fn main() {
         .drain()
         .map(|(key, pipeline)| {
             let mut backend = pipeline.backend.into_recipient();
-            let mut steps = pipeline.steps.unwrap_or(vec![]);
+            let mut steps = pipeline.steps.unwrap_or_else(|| vec![]);
             steps.reverse();
 
             for step in steps.drain(..) {
@@ -85,7 +87,7 @@ fn main() {
                     .map(|p| {
                         backends
                             .get(p)
-                            .expect(&format!("Invalid configuration: pipeline {} not found!", p))
+                            .unwrap_or_else(|| panic!("Invalid configuration: pipeline {} not found!", p))
                             .clone()
                     })
                     .collect::<Vec<Recipient<Message>>>();
@@ -100,5 +102,5 @@ fn main() {
         });
     });
 
-    system.run();
+    system.run().unwrap();
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -102,5 +102,5 @@ impl Measurement {
 
 pub fn timestamp_now() -> u64 {
     let duration = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    duration.as_secs() * (1e9 as u64) + duration.subsec_nanos() as u64
+    duration.as_secs() * (1e9 as u64) + u64::from(duration.subsec_nanos())
 }


### PR DESCRIPTION
This PR fixes clippy warnings and updates the build code after the redbpf changes coming in https://github.com/redsift/redbpf/pull/4.

It also adds ubuntu (18.04 and 16.04) and fedora (29) build jobs to circleci.
