### PR TITLE
Revise types of tags

### DIFF
--- a/bpf/connection.h
+++ b/bpf/connection.h
@@ -55,7 +55,7 @@ struct _data_connect get_connection_details(struct sock **skpp, u64 pid) {
   struct _data_connect data = {};
   struct inet_sock *skp = inet_sk(*skpp);
 
-  data.id = pid;
+  data.id = pid >> 32;
   data.ts = bpf_ktime_get_ns();
 
   bpf_get_current_comm(&data.comm, sizeof(data.comm));

--- a/bpf/file.c
+++ b/bpf/file.c
@@ -98,7 +98,7 @@ int track_file_access(struct pt_regs *ctx,  u8 is_read)
   };
 
   struct _data_file *info = &vol.file;
-  info->id = tid;
+  info->id = tid >> 32;
   info->ts = bpf_ktime_get_ns();
 
   struct qstr d_name;

--- a/bpf/syscall.c
+++ b/bpf/syscall.c
@@ -58,7 +58,7 @@ int syscall_tp_handler(struct pt_regs *ctx) {
   
   struct _data_syscall_tracepoint data = {};
   data.syscall_nr = PT_REGS_RC(ctx);
-  data.id = pid_tgid;
+  data.id = pid_tgid >> 32;
   bpf_get_current_comm(&data.comm, sizeof(data.comm));
 
   u32 cpu = bpf_get_smp_processor_id();

--- a/src/grains/connection.rs
+++ b/src/grains/connection.rs
@@ -59,8 +59,8 @@ impl ToTags for Connection {
     fn to_tags(self) -> Tags {
         let mut tags = Tags::new();
 
-        tags.insert("process", self.name.as_str());
-        tags.insert("task_id", self.task_id.to_string());
+        tags.insert("process_str", self.name.as_str());
+        tags.insert("process_id", self.task_id.to_string());
 
         tags.insert("d_ip", self.destination_ip.to_string());
         tags.insert("d_port", self.destination_port.to_string());

--- a/src/grains/dns.rs
+++ b/src/grains/dns.rs
@@ -69,10 +69,11 @@ impl ToTags for DNSQuery {
     fn to_tags(self) -> Tags {
         let mut tags = Tags::new();
 
-        tags.insert("q_dnstype", self.qclass.to_string());
+        tags.insert("q_dnstype", self.qtype.to_string());
         tags.insert("q_dnsclass", self.qclass.to_string());
-        tags.insert("q_dnsaddr", self.address.to_string());
         tags.insert("q_dnsid", self.id.to_string());
+
+        tags.insert("q_domain_str", self.address.to_string());
 
         tags.insert("d_ip", self.destination_ip.to_string());
         tags.insert("d_port", self.destination_port.to_string());

--- a/src/grains/file.rs
+++ b/src/grains/file.rs
@@ -110,10 +110,10 @@ impl ToTags for FileAccess {
     fn to_tags(self) -> Tags {
         let mut tags = Tags::new();
 
-        tags.insert("task_id", self.id.to_string());
-        tags.insert("process", self.process);
-        tags.insert("path", self.path);
-        tags.insert("ino", self.ino.to_string());
+        tags.insert("process_id", self.id.to_string());
+        tags.insert("process_str", self.process);
+        tags.insert("path_str", self.path);
+        tags.insert("ino_id", self.ino.to_string());
 
         tags
     }

--- a/src/grains/syscalls.rs
+++ b/src/grains/syscalls.rs
@@ -55,10 +55,10 @@ impl EBPFGrain<'static> for Syscall {
             let mut tags = Tags::new();
 
             let syscall_name = ksyms[&data.syscall_nr].clone();
-            tags.insert("syscall", syscall_name);
+            tags.insert("syscall_str", syscall_name);
 
-            tags.insert("task_id", data.id.to_string());
-            tags.insert("process", crate::grains::to_string(
+            tags.insert("process_id", data.id.to_string());
+            tags.insert("process_str", crate::grains::to_string(
                 unsafe { &*(&data.comm as *const [i8] as *const [u8]) }
             ));
 

--- a/src/grains/tls.rs
+++ b/src/grains/tls.rs
@@ -53,7 +53,7 @@ fn tls_to_message(buf: &[u8]) -> Option<Message> {
     };
 
     let mut tags = tag_ip_and_ports(buf);
-    tags.insert("version", format!("{:?}", &version));
+    tags.insert("tls_version", format!("{:?}", &version));
 
     use self::HandshakePayload::*;
     match handshake.payload {


### PR DESCRIPTION
This is an attempt to make tags emitted by grains more consistent.
The following replacements have been made:

    pid     -> process_id
    process -> process_str

    q_dnsaddr -> q_domain_str

    path -> path_str
    ino  -> ino_id

    syscall -> syscall_str


Some of the types are clearly redundant, but it will make them consistent with other, less straightforward tags.

This PR also changes makes grains that emitted PID_TGID in `pid` to emit only `PID`, ie. omit the thread id from the emitted `pid` tag. This should align more closely with expectations, but removes information about specific threads.