### PR TITLE
Aarch64 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [build-dependencies]
 failure = "0.1"
-redbpf = { version = "^0.3.2", features = ["build"] }
+redbpf = { version = "^0.3.3", features = ["build"] }
 
 [build-dependencies.capnpc]
 version = "^0.9.3"
@@ -30,7 +30,7 @@ lazy_static = "1.1.0"
 
 libc = "0.2"
 lazy-socket = "0.3"
-redbpf = "^0.3"
+redbpf = "^0.3.3"
 
 uuid = { version = "0.6", features = ["v4"] }
 serde = "^1.0"

--- a/bpf/connection.h
+++ b/bpf/connection.h
@@ -19,8 +19,7 @@
 #ifndef __CONNECTION_H
 #define __CONNECTION_H
 
-#include <linux/kconfig.h>
-#include <linux/types.h>
+#include "include/bpf_helpers.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
@@ -29,10 +28,6 @@
 #include <net/sock.h>
 #include <linux/ptrace.h>
 #pragma clang diagnostic pop
-
-#include <linux/version.h>
-#include <linux/bpf.h>
-#include "include/bpf_helpers.h"
 
 struct _data_connect {
   u64 id;

--- a/bpf/dns.c
+++ b/bpf/dns.c
@@ -17,6 +17,7 @@
  */
 
 #include "dns.h"
+#include "include/bpf_helpers.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
@@ -31,9 +32,6 @@
 #include <linux/udp.h>
 
 #include <linux/skbuff.h>
-#include <linux/version.h>
-#include <linux/bpf.h>
-#include "include/bpf_helpers.h"
 
 struct bpf_map_def SEC("maps/dns_queries") dns_queries = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,

--- a/bpf/file.c
+++ b/bpf/file.c
@@ -24,10 +24,6 @@
 #include <linux/stat.h>
 #pragma clang diagnostic pop
 
-#include <linux/version.h>
-#include <linux/bpf.h>
-#include "include/bpf_helpers.h"
-
 struct bpf_map_def SEC("maps/actionlist") actionlist = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(u64),

--- a/bpf/file.h
+++ b/bpf/file.h
@@ -19,8 +19,7 @@
 #ifndef __FILE_H
 #define __FILE_H
 
-#include <linux/kconfig.h>
-#include <linux/types.h>
+#include "include/bpf_helpers.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"

--- a/bpf/include/bpf_helpers.h
+++ b/bpf/include/bpf_helpers.h
@@ -6,7 +6,19 @@
 #ifndef __BPF_HELPERS_H
 #define __BPF_HELPERS_H
 
+#include <linux/kconfig.h>
+#include <linux/types.h>
+#include <linux/version.h>
+
+#ifdef asm_volatile_goto
+#undef asm_volatile_goto
+#define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
+#endif
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-label"
 #include <linux/bpf.h>
+#pragma clang diagnostic pop
 
 /* helper macro to place programs, maps, license in
  * different sections in elf_bpf file. Section names

--- a/bpf/include/bpf_helpers.h
+++ b/bpf/include/bpf_helpers.h
@@ -17,6 +17,7 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-label"
+#pragma clang diagnostic ignored "-Waddress-of-packed-member"
 #include <linux/bpf.h>
 #pragma clang diagnostic pop
 

--- a/bpf/syscall.c
+++ b/bpf/syscall.c
@@ -19,9 +19,6 @@
 #include "syscall.h"
 
 #include <linux/skbuff.h>
-#include <linux/version.h>
-#include <linux/bpf.h>
-#include "include/bpf_helpers.h"
 
 struct bpf_map_def SEC("maps/syscall_tp_trigger") syscall_event = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,

--- a/bpf/syscall.h
+++ b/bpf/syscall.h
@@ -19,18 +19,13 @@
 #ifndef __SYSCALL_H
 #define __SYSCALL_H
 
-#include <linux/kconfig.h>
-#include <linux/types.h>
+#include "include/bpf_helpers.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
 #pragma clang diagnostic ignored "-Waddress-of-packed-member"
 #include <linux/ptrace.h>
 #pragma clang diagnostic pop
-
-#include <linux/version.h>
-#include <linux/bpf.h>
-#include "include/bpf_helpers.h"
 
 struct _data_syscall_tracepoint {
   u64 id;

--- a/bpf/tcpv4.c
+++ b/bpf/tcpv4.c
@@ -17,6 +17,7 @@
  */
 
 #include "connection.h"
+#include "include/bpf_helpers.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
@@ -24,10 +25,6 @@
 #include <net/sock.h>
 #include <net/inet_sock.h>
 #pragma clang diagnostic pop
-
-#include <linux/version.h>
-#include <linux/bpf.h>
-#include "include/bpf_helpers.h"
 
 struct bpf_map_def SEC("maps/currsock") currsock = {
     .type = BPF_MAP_TYPE_HASH,

--- a/bpf/tls.c
+++ b/bpf/tls.c
@@ -16,12 +16,12 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include <linux/kconfig.h>
-#include <linux/types.h>
+#include "include/bpf_helpers.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
 #pragma clang diagnostic ignored "-Waddress-of-packed-member"
+#pragma clang diagnostic ignored "-Warray-bounds"
 #include <net/sock.h>
 #include <net/inet_sock.h>
 #pragma clang diagnostic pop
@@ -32,9 +32,6 @@
 #include <uapi/linux/tcp.h>
 
 #include <linux/skbuff.h>
-#include <linux/version.h>
-#include <linux/bpf.h>
-#include "include/bpf_helpers.h"
 
 #define ETH_HLEN 14
 

--- a/bpf/udp.c
+++ b/bpf/udp.c
@@ -17,6 +17,7 @@
  */
 
 #include "connection.h"
+#include "include/bpf_helpers.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
@@ -26,9 +27,6 @@
 #pragma clang diagnostic pop
 
 #include <linux/skbuff.h>
-#include <linux/version.h>
-#include <linux/bpf.h>
-#include "include/bpf_helpers.h"
 
 struct bpf_map_def SEC("maps/udp_volume") udp_volume = {
     .type = BPF_MAP_TYPE_PERF_EVENT_ARRAY,

--- a/src/grains/connection.rs
+++ b/src/grains/connection.rs
@@ -1,4 +1,5 @@
 use std::net::Ipv4Addr;
+use std::os::raw::c_char;
 
 use crate::grains::protocol::ip::to_ipv4;
 use crate::grains::*;
@@ -78,7 +79,7 @@ impl From<_data_connect> for Connection {
     fn from(data: _data_connect) -> Connection {
         Connection {
             task_id: data.id,
-            name: to_string(unsafe { &*(&data.comm as *const [i8] as *const [u8]) }),
+            name: to_string(unsafe { &*(&data.comm as *const [c_char] as *const [u8]) }),
             source_ip: to_ipv4(data.saddr),
             destination_ip: to_ipv4(data.daddr),
             destination_port: to_le(data.dport),

--- a/src/grains/dns.rs
+++ b/src/grains/dns.rs
@@ -1,3 +1,5 @@
+use std::os::raw::c_char;
+
 use crate::grains::protocol::ip::to_ipv4;
 use crate::grains::*;
 
@@ -57,7 +59,7 @@ impl From<_data_dns_query> for DNSQuery {
             destination_port: to_le(data.dport),
             source_port: to_le(data.sport),
             address: from_dns_prefix_labels(unsafe {
-                &*(&data.address as *const [i8] as *const [u8])
+                &*(&data.address as *const [c_char] as *const [u8])
             }),
             qtype: to_le(data.qtype),
             qclass: to_le(data.qclass),

--- a/src/grains/file.rs
+++ b/src/grains/file.rs
@@ -3,6 +3,7 @@
 use std::cmp::min;
 use std::fs::metadata;
 use std::os::unix::fs::MetadataExt;
+use std::os::raw::c_char;
 
 use redbpf::{Module, VoidPtr};
 
@@ -86,7 +87,7 @@ impl From<_data_volume> for FileAccess {
         let path = path_segments
             .iter()
             .map(|s| {
-                let namebuf = unsafe { &*(&s.name as *const [i8] as *const [u8]) };
+                let namebuf = unsafe { &*(&s.name as *const [c_char] as *const [u8]) };
                 let len = min(s.name.len(), s.nlen as usize) as usize;
                 to_string(&namebuf[0..len as usize])
             })
@@ -97,7 +98,7 @@ impl From<_data_volume> for FileAccess {
 
         FileAccess {
             id: data.file.id,
-            process: to_string(unsafe { &*(&data.file.comm as *const [i8] as *const [u8]) }),
+            process: to_string(unsafe { &*(&data.file.comm as *const [c_char] as *const [u8]) }),
             path,
             ino,
             read: data.read,

--- a/src/grains/syscalls.rs
+++ b/src/grains/syscalls.rs
@@ -1,3 +1,4 @@
+use std::os::raw::c_char;
 use std::collections::HashMap;
 use std::fs;
 
@@ -59,7 +60,7 @@ impl EBPFGrain<'static> for Syscall {
 
             tags.insert("process_id", data.id.to_string());
             tags.insert("process_str", crate::grains::to_string(
-                unsafe { &*(&data.comm as *const [i8] as *const [u8]) }
+                unsafe { &*(&data.comm as *const [c_char] as *const [u8]) }
             ));
 
             Some(Message::Single(Measurement::new(

--- a/src/grains/syscalls.rs
+++ b/src/grains/syscalls.rs
@@ -18,13 +18,19 @@ pub struct SyscallConfig {
 }
 pub struct Syscall(pub SyscallConfig);
 
+#[cfg(target_arch = "x86_64")]
+const SYSCALL_PREFIX: &'static str = "__x64_sys_{}";
+
+#[cfg(target_arch = "aarch64")]
+const SYSCALL_PREFIX: &'static str = "__arm64_sys_{}";
+
 impl EBPFProbe for Grain<Syscall> {
     fn attach(&mut self) -> MessageStreams {
         let bind_to = self.native.0.monitor_syscalls.clone();
         bind_to
             .iter()
             .flat_map(|syscall| {
-                self.attach_kprobes_to_names(&format!("__x64_sys_{}", syscall))
+                self.attach_kprobes_to_names(&format!(SYSCALL_PREFIX, syscall))
             })
             .collect()
     }

--- a/src/grains/syscalls.rs
+++ b/src/grains/syscalls.rs
@@ -19,10 +19,10 @@ pub struct SyscallConfig {
 pub struct Syscall(pub SyscallConfig);
 
 #[cfg(target_arch = "x86_64")]
-const SYSCALL_PREFIX: &'static str = "__x64_sys_{}";
+const SYSCALL_PREFIX: &'static str = "__x64_sys_";
 
 #[cfg(target_arch = "aarch64")]
-const SYSCALL_PREFIX: &'static str = "__arm64_sys_{}";
+const SYSCALL_PREFIX: &'static str = "__arm64_sys_";
 
 impl EBPFProbe for Grain<Syscall> {
     fn attach(&mut self) -> MessageStreams {
@@ -30,7 +30,7 @@ impl EBPFProbe for Grain<Syscall> {
         bind_to
             .iter()
             .flat_map(|syscall| {
-                self.attach_kprobes_to_names(&format!(SYSCALL_PREFIX, syscall))
+                self.attach_kprobes_to_names(&format!("{}{}", SYSCALL_PREFIX, syscall))
             })
             .collect()
     }


### PR DESCRIPTION
Targeting a Raspberry Pi 4, but the changes should be generic enough to support any `arm64` boards.

This PR depends on the corresponding RedBPF PR https://github.com/redsift/redbpf/pull/5.