### PR TITLE
Run the EBPF and StatsD probes on a separate IO thread

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use actix::{Actor, Recipient};
+use actix::{Actor, Arbiter, Recipient};
 use log::LevelFilter;
 
 use crate::aggregations::*;
@@ -109,10 +109,10 @@ pub enum ProbeActor {
 }
 
 impl ProbeActor {
-    pub fn start(self) {
+    pub fn start(self, io: &Arbiter) {
         match self {
-            ProbeActor::EBPF(a) => { a.start(); },
-            ProbeActor::StatsD(a) => { a.start(); }
+            ProbeActor::EBPF(a) => { Actor::start_in_arbiter(io, |_| a); },
+            ProbeActor::StatsD(a) => { Actor::start_in_arbiter(io, |_| a); }
             ProbeActor::Osquery(a) => { a.start(); }
         };
     }

--- a/src/grains/ebpf.rs
+++ b/src/grains/ebpf.rs
@@ -152,7 +152,7 @@ where
     }
 }
 
-pub trait EBPFProbe {
+pub trait EBPFProbe: Send {
     fn attach(&mut self) -> MessageStreams;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ fn main() {
     }));
 
     let system = actix::System::new("userspace");
+    let io = actix::Arbiter::new();
 
     let mut config: config::Config = {
         let file = env::args().nth(1).expect("Usage: ingraind <config file>");
@@ -93,7 +94,7 @@ fn main() {
         .collect();
 
     for actor in probe_actors {
-        actor.start();
+        actor.start(&io);
     }
 
     system.run().unwrap();


### PR DESCRIPTION
EBPF and StatsD metrics are consumed from ringbuffers so we want to
read as fast as possible.

Osquery is left on the main thread since it's not latency sensitive.