### PR TITLE
gke: update config map to use new Network grain

### DIFF
--- a/tests/gke/config.yaml
+++ b/tests/gke/config.yaml
@@ -15,18 +15,10 @@ data:
     type = "Files"
     monitor_dirs = ["/root/rootfs"]
 
-    # The TCP4 grain will track outbound TCP/IPv4 connections, as well as
-    # send/receive metrics about established connections
     [[probe]]
     pipelines = ["staging"]
     [probe.config]
-    type = "TCP4"
-
-    # The UDP grain will track send/receive metrics about UDP/IPv4 connections.
-    [[probe]]
-    pipelines = ["staging"]
-    [probe.config]
-    type = "UDP"
+    type = "Network"
 
     [[probe]]
     pipelines = ["staging"]


### PR DESCRIPTION
The TCP4 and UDP grains have been replace by Network, so the config map needs to be updated.