### PR TITLE
Add test probe

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,7 @@ pub enum Grain {
     Syscall(syscalls::SyscallConfig),
     StatsD(grains::statsd::StatsdConfig),
     Osquery(osquery::OsqueryConfig),
+    Test(grains::test::TestProbeConfig),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -113,6 +114,7 @@ pub enum ProbeActor {
     EBPF(EBPFActor),
     StatsD(grains::statsd::Statsd),
     Osquery(osquery::Osquery),
+    Test(grains::test::TestProbe)
 }
 
 impl ProbeActor {
@@ -122,6 +124,9 @@ impl ProbeActor {
                 Actor::start_in_arbiter(io, |_| a);
             }
             ProbeActor::StatsD(a) => {
+                Actor::start_in_arbiter(io, |_| a);
+            }
+            ProbeActor::Test(a) => {
                 Actor::start_in_arbiter(io, |_| a);
             }
             ProbeActor::Osquery(a) => {
@@ -139,6 +144,9 @@ impl Grain {
             }
             Grain::Osquery(config) => {
                 ProbeActor::Osquery(osquery::Osquery::with_config(config, recipients))
+            }
+            Grain::Test(config) => {
+                ProbeActor::Test(grains::test::TestProbe::with_config(config, recipients))
             }
             _ => {
                 let probe: Box<dyn EBPFProbe> = match self {

--- a/src/grains/mod.rs
+++ b/src/grains/mod.rs
@@ -9,6 +9,7 @@ pub mod statsd;
 pub mod syscalls;
 pub mod tls;
 pub mod network;
+pub mod test;
 
 pub use crate::grains::ebpf::*;
 pub use crate::grains::ebpf_io::*;

--- a/src/grains/test.rs
+++ b/src/grains/test.rs
@@ -1,0 +1,101 @@
+use actix::{Actor, AsyncContext, Context, Recipient, StreamHandler};
+use futures::{Async, Poll, Stream};
+
+use crate::backends::Message;
+use crate::metrics::{kind, timestamp_now, Measurement, Tags, Unit};
+
+pub struct TestProbe {
+    config: TestProbeConfig,
+    recipients: Vec<Recipient<Message>>,
+}
+
+impl TestProbe {
+    pub fn with_config(config: TestProbeConfig, recipients: Vec<Recipient<Message>>) -> Self {
+        TestProbe { config, recipients }
+    }
+}
+
+impl Actor for TestProbe {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        info!("debug probe started");
+        let unit = Unit::try_from_str(
+            &self.config.measurement_type,
+            self.config.measurement.parse().unwrap_or_default(),
+        )
+        .unwrap();
+        let kind = kind::try_from_str(&self.config.aggregation_type.as_ref().unwrap()).unwrap();
+        ctx.add_stream(MeasurementStream::new(
+            self.config.name.clone(),
+            unit,
+            kind,
+            self.config.tags.clone(),
+        ));
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        info!("debug daemon stopped");
+    }
+}
+
+impl StreamHandler<Message, ()> for TestProbe {
+    fn handle(&mut self, message: Message, _ctx: &mut Context<TestProbe>) {
+        for recipient in &self.recipients {
+            recipient.do_send(message.clone()).unwrap();
+        }
+    }
+}
+
+pub struct MeasurementStream {
+    name: String,
+    unit: Unit,
+    kind: kind::Kind,
+    tags: Vec<Tag>,
+}
+
+impl MeasurementStream {
+    fn new(name: String, unit: Unit, kind: kind::Kind, tags: Vec<Tag>) -> Self {
+        MeasurementStream {
+            name,
+            unit,
+            kind,
+            tags,
+        }
+    }
+}
+
+impl Stream for MeasurementStream {
+    type Item = Message;
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let mut tags = Tags::new();
+        for (key, value) in &self.tags {
+            let value = match value.as_str() {
+                "$TS" => format!("{}", timestamp_now()),
+                _ => value.clone(),
+            };
+            tags.insert(key.clone(), value);
+        }
+        let measurement = Measurement::new(
+            self.kind,
+            self.name.clone(),
+            self.unit.clone(),
+            tags,
+        );
+        let message = Message::Single(measurement);
+        Ok(Async::Ready(Some(message)))
+    }
+}
+
+pub type Tag = (String, String);
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TestProbeConfig {
+    name: String,
+    measurement: String,
+    measurement_type: String,
+    aggregation_type: Option<String>,
+    tags: Vec<Tag>,
+}


### PR DESCRIPTION
The test probe can be used to generate arbitrary metrics for testing. Eg:

[[probe]]
...
[probe.config]
type = "Test"
name = "foo"
measurement = "1"
measurement_type = "Count"
aggregation_type = "COUNTER"
tags = [["bar", "baz"], ["bad", "$TS"]]

If a tag value is the string $TS, it will be replaced with the return
value of timestamp_now().