### PR TITLE
backends: http: add support for optionally processing measurements in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ log = { version = "^0.4", features = ["serde"] }
 env_logger = "^0.5.13"
 syslog = "^4.0"
 
+rayon = "1.2.1"
+
 dns-parser = "0.8"
 hdrhistogram = { version = "6.3", default-features = false }
 ingraind-probes = { path = "ingraind-probes" }

--- a/src/aggregations/buffer.rs
+++ b/src/aggregations/buffer.rs
@@ -240,8 +240,8 @@ impl Buffer {
     }
 
     fn flush(&mut self, _ctx: &mut Context<Self>) {
-        info!("flushing");
         let metrics = self.aggregator.flush();
+        info!("flushing metrics: {}", metrics.len());
         if !metrics.is_empty() {
             let message = Message::List(metrics);
             self.upstream.do_send(message.clone()).unwrap();

--- a/src/backends/encoders.rs
+++ b/src/backends/encoders.rs
@@ -2,24 +2,22 @@ use std::collections::HashMap;
 
 use serde_json;
 
-use super::{Kind, Measurement, Message, Unit};
+use super::{Kind, Measurement, Unit};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug)]
 pub enum Encoding {
     JSON,
     #[cfg(feature = "capnp")]
     Capnp,
 }
 
-pub type Encoder = Box<dyn Fn(&[Measurement]) -> Vec<u8>>;
-
 impl Encoding {
-    pub fn to_encoder(&self) -> Encoder {
-        Box::new(match self {
-            Encoding::JSON => to_json,
+    pub fn encode(&self, measurements: &[Measurement]) -> Vec<u8> {
+        match self {
+            Encoding::JSON => to_json(measurements),
             #[cfg(feature = "capnp")]
-            Encoding::Capnp => to_capnp,
-        })
+            Encoding::Capnp => to_capnp(measurements)
+        }
     }
 }
 

--- a/src/backends/http.rs
+++ b/src/backends/http.rs
@@ -5,14 +5,14 @@ use futures::{finished, Future};
 use hyper::{client::HttpConnector, header, Body, Client, HeaderMap, Method, Request, Uri};
 use hyper_rustls::HttpsConnector;
 
-use crate::backends::encoders::{Encoder, Encoding};
+use crate::backends::encoders::Encoding;
 use crate::backends::Message;
 
 pub struct HTTP {
     headers: HeaderMap,
     uri: Uri,
     client: Client<HttpsConnector<HttpConnector>>,
-    encoder: Encoder,
+    encoding: Encoding,
     content_type: String,
 }
 
@@ -51,13 +51,11 @@ impl HTTP {
         }
         .to_string();
 
-        let encoder = encoding.to_encoder();
-
         HTTP {
             headers,
             client,
             uri,
-            encoder,
+            encoding,
             content_type,
         }
     }
@@ -76,7 +74,7 @@ impl Handler<Message> for HTTP {
             Message::List(ms) => ms,
         };
 
-        let mut req = Request::new(Body::from((self.encoder)(&measurements)));
+        let mut req = Request::new(Body::from(self.encoding.encode(&measurements)));
         *req.method_mut() = Method::POST;
         *req.uri_mut() = self.uri.clone();
         req.headers_mut().clone_from(&self.headers);


### PR DESCRIPTION
When `parallel_chunk_size` is set in `config.toml`, inbound measurements are processed in parallel in chunks in a thread pool and sent out as multiple HTTP requests.

This addresses the case in which measurements produced by N cpus overrun the backend processing measurements on 1 thread.

A simple way to test this change is with the following config:

```
[[probe]]
pipelines = ["http"]
[probe.config]
type = "Test"
name = "foo"
measurement = "1"
measurement_type = "Count"
aggregation_type = "COUNTER"
tags = [["bar", "baz"], ["bad", "$TS"]]

[pipeline.http.config]
backend = "HTTP"
uri = "http://localhost:1234"
headers = {}
parallel_chunk_size = 10000

[[pipeline.http.steps]]
type = "Buffer"
interval_s = 1
```

Without `parallel_chunk_size`, the above config makes ingraind go out of memory on a host with 8 cores and 4G of ram very quickly. Ingraind starts at around 400MB of RAM and grows of about 40MB per second as the actor mailboxes fill up as the http backend can't keep up.

With `parallel_chunk_size` set, memory stays instead pretty much constant.