### PR TITLE
Performance fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/ingraind_probes/target
+/ingraind-probes/target
 /target
 /kernel
 **/*.rs.bk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bumpalo"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +428,14 @@ dependencies = [
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml_edit 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -521,6 +540,39 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "criterion"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tinytemplate 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +650,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1025,6 +1106,7 @@ dependencies = [
  "capnp 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-bpf 0.9.5 (git+https://github.com/redsift/redbpf)",
+ "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "epoll 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1039,6 +1121,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrohash 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redbpf 0.9.4 (git+https://github.com/redsift/redbpf)",
  "redbpf-probes 0.9.6 (git+https://github.com/redsift/redbpf)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1051,6 +1134,7 @@ dependencies = [
  "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1089,6 +1173,14 @@ dependencies = [
 name = "itertools"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "itoa"
@@ -1203,6 +1295,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memoffset"
@@ -1579,6 +1674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_os"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1697,36 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1669,6 +1803,14 @@ dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1804,6 +1946,14 @@ dependencies = [
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2065,6 +2215,15 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2448,6 +2607,16 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "want"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum bpf-sys 0.9.4 (git+https://github.com/redsift/redbpf)" = "<none>"
+"checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
@@ -2698,6 +2868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum capnp 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "50bc40e18a764f679fd13673b61c12d2c45c1581a2c6c949ffa424d9f58716c7"
 "checksum capnpc 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "097449bb52d9c96340c88e9726be5ad8dea78bd6ee4a27c7e5c3fbe0d6f60056"
 "checksum cargo-bpf 0.9.5 (git+https://github.com/redsift/redbpf)" = "<none>"
+"checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 "checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -2710,14 +2881,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum const-random-macro 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c750ec12b83377637110d5a57f5ae08e895b06c4b16e2bdbf1a94ef717428c59"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum copyless 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ff9c56c9fb2a49c05ef0e431485a22400af20d33226dc0764d891d09e724127"
+"checksum criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
+"checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+"checksum csv 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "11f8cbd084b9a431d52dfac0b8428a26b68f1061138a7bea18aa56b9cdf55266"
+"checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum cty 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7313c0d620d0cb4dbd9d019e461a4beb501071ff46ec0ab933efb4daa76d73e3"
 "checksum derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d944ac6003ed268757ef1ee686753b57efc5fcf0ebe7b64c9fc81e7e32ff839"
@@ -2768,6 +2944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f"
 "checksum itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c4a9b56eb56058f43dc66e58f40a214b2ccbc9f3df51861b63d51dec7b65bc3f"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "1c840fdb2167497b0bd0db43d6dfe61e91637fa72f9d061f8bd17ddc44ba6414"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -2828,8 +3005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
 "checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
+"checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+"checksum rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redbpf 0.9.4 (git+https://github.com/redsift/redbpf)" = "<none>"
 "checksum redbpf-macros 0.9.4 (git+https://github.com/redsift/redbpf)" = "<none>"
@@ -2837,6 +3018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+"checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
@@ -2849,6 +3031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+"checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
 "checksum scroll_derive 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1aa96c45e7f5a91cb7fabe7b279f02fea7126239fc40b732316e8b6a2d0fcb"
@@ -2882,6 +3065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum tinytemplate 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
@@ -2918,6 +3102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "29ae32af33bacd663a9a28241abecf01f2be64e6a185c6139b04f18b6385c5f2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ futures = "^0.1"
 tokio = "0.1"
 tokio-reactor = "0.1"
 tokio-udp = "0.1"
+tokio-timer = "0.2.12"
 bytes = "0.4"
 mio = "0.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,13 @@ default-features = false
 features = ["rustls"]
 optional = true
 
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "aggregator"
+harness = false
+
 [features]
 default = ["statsd-backend", "http-backend", "capnp-encoding"]
 s3-backend = ["rusoto_core", "rusoto_s3"]

--- a/benches/aggregator.rs
+++ b/benches/aggregator.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, BatchSize
 use ingraind::aggregations::buffer::Aggregator;
 use ingraind::metrics::{kind, timestamp_now, Measurement, Tags, Unit};
 
-pub fn record_flush(c: &mut Criterion) {
+pub fn record(c: &mut Criterion) {
     let mut metrics = Vec::new();
     for i in 0..1000 {
         let mut tags = Tags::new();
@@ -15,16 +15,12 @@ pub fn record_flush(c: &mut Criterion) {
             tags,
         ));
     }
-    c.bench_function("record_flush", |b| {
+    c.bench_function("record", |b| {
         b.iter_batched(
             || metrics.clone(),
             |metrics| {
                 let mut aggregator = Aggregator::new(true);
                 for m in metrics.iter().cloned() {
-                    aggregator.record(m);
-                }
-                aggregator.flush();
-                for m in metrics {
                     aggregator.record(m);
                 }
             },
@@ -55,5 +51,5 @@ pub fn flush(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, record_flush, flush);
+criterion_group!(benches, record, flush);
 criterion_main!(benches);

--- a/benches/aggregator.rs
+++ b/benches/aggregator.rs
@@ -1,0 +1,59 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BatchSize};
+use ingraind::aggregations::buffer::Aggregator;
+use ingraind::metrics::{kind, timestamp_now, Measurement, Tags, Unit};
+
+pub fn record_flush(c: &mut Criterion) {
+    let mut metrics = Vec::new();
+    for i in 0..1000 {
+        let mut tags = Tags::new();
+        tags.insert("foo", "bar");
+        tags.insert("bar", "baz");
+        metrics.push(Measurement::new(
+            kind::COUNTER,
+            format!("foo_{}", i),
+            Unit::Count(1),
+            tags,
+        ));
+    }
+    c.bench_function("record_flush", |b| {
+        b.iter_batched(
+            || metrics.clone(),
+            |metrics| {
+                let mut aggregator = Aggregator::new(true);
+                for m in metrics.iter().cloned() {
+                    aggregator.record(m);
+                }
+                aggregator.flush();
+                for m in metrics {
+                    aggregator.record(m);
+                }
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+pub fn flush(c: &mut Criterion) {
+    let mut aggregator = Aggregator::new(true);
+    for i in 0..5000 {
+        let mut tags = Tags::new();
+        tags.insert("foo", "bar");
+        tags.insert("bar", "baz");
+        aggregator.record(Measurement::new(
+            kind::COUNTER,
+            format!("foo_{}", i),
+            Unit::Count(1),
+            tags,
+        ));
+    }
+    c.bench_function("flush", |b| {
+        b.iter_batched(
+            || aggregator.clone(),
+            |mut aggregator| aggregator.flush(),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, record_flush, flush);
+criterion_main!(benches);

--- a/src/aggregations/buffer.rs
+++ b/src/aggregations/buffer.rs
@@ -51,19 +51,6 @@ impl Aggregator {
         }
     }
 
-    pub fn max_len(&self) -> usize {
-        *[
-            self.counters.len(),
-            self.gauges.len(),
-            self.timers.len(),
-            self.sets.len(),
-            self.histograms.len(),
-        ]
-        .iter()
-        .max()
-        .unwrap()
-    }
-
     pub fn record<T: Into<Measurement>>(&mut self, measurement: T) {
         let measurement = measurement.into();
         let key = measurement_key(&measurement);
@@ -291,12 +278,6 @@ impl Handler<Message> for Buffer {
     type Result = ();
 
     fn handle(&mut self, msg: Message, ctx: &mut Context<Self>) -> Self::Result {
-        if let Some(max_elems) = self.config.max_records {
-            if self.aggregator.max_len() > max_elems as usize {
-                self.flush(ctx);
-            }
-        }
-
         if self.last_flush_time.elapsed() >= self.flush_period {
             self.flush(ctx);
         }
@@ -325,7 +306,6 @@ pub struct BufferConfig {
     #[serde(default = "default_interval_ms")]
     pub interval_ms: u64,
     pub interval_s: Option<u64>,
-    pub max_records: Option<u64>,
     #[serde(default = "default_enable_histograms")]
     pub enable_histograms: bool,
 }

--- a/src/aggregations/buffer.rs
+++ b/src/aggregations/buffer.rs
@@ -14,20 +14,20 @@ use crate::metrics::{kind, Measurement, Tags, Unit, UnitType};
 const PERCENTILES: [f64; 6] = [25f64, 50f64, 75f64, 90f64, 95f64, 99f64];
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct MeasurementKey {
+pub struct MeasurementKey {
     name: String,
     tags_hash: u64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-struct AggregatedMetric<T: PartialEq> {
+pub struct AggregatedMetric<T: PartialEq> {
     value: T,
     unit: UnitType,
     tags: Tags,
 }
 
-#[derive(Debug)]
-struct Aggregator {
+#[derive(Debug, Clone)]
+pub struct Aggregator {
     counters: HashMap<MeasurementKey, AggregatedMetric<f64>>,
     gauges: HashMap<MeasurementKey, AggregatedMetric<f64>>,
     timers: HashMap<MeasurementKey, AggregatedMetric<Vec<f64>>>,

--- a/src/aggregations/buffer.rs
+++ b/src/aggregations/buffer.rs
@@ -282,7 +282,7 @@ impl Handler<Message> for Buffer {
     fn handle(&mut self, msg: Message, ctx: &mut Context<Self>) -> Self::Result {
         if let Some(max_elems) = self.config.max_records {
             if self.aggregator.max_len() > max_elems as usize {
-                self.aggregator.flush();
+                self.flush(ctx);
             }
         }
 

--- a/src/aggregations/buffer.rs
+++ b/src/aggregations/buffer.rs
@@ -274,7 +274,7 @@ impl Buffer {
         info!("flushing metrics: {}", metrics.len());
         if !metrics.is_empty() {
             let message = Message::List(metrics);
-            self.upstream.do_send(message.clone()).unwrap();
+            self.upstream.do_send(message).unwrap();
         }
     }
 }

--- a/src/aggregations/buffer.rs
+++ b/src/aggregations/buffer.rs
@@ -151,6 +151,12 @@ impl Aggregator {
     }
 
     pub fn flush(&mut self) -> Vec<Measurement> {
+        self.counters.shrink_to_fit();
+        self.gauges.shrink_to_fit();
+        self.timers.shrink_to_fit();
+        self.sets.shrink_to_fit();
+        self.histograms.shrink_to_fit();
+
         let mut metrics = Vec::new();
         metrics.extend(self.counters.drain().map(|(k, v)| {
             Measurement::new(
@@ -160,12 +166,10 @@ impl Aggregator {
                 v.tags,
             )
         }));
-        self.counters.shrink_to_fit();
-        
+
         metrics.extend(self.gauges.drain().map(|(k, v)| {
             Measurement::new(kind::GAUGE, k.name, v.unit.to_unit(v.value as u64), v.tags)
         }));
-        self.gauges.shrink_to_fit();
         
         for (k, mut v) in self.timers.drain() {
             let tags = v.tags;
@@ -178,7 +182,6 @@ impl Aggregator {
                 )
             }));
         }
-        self.timers.shrink_to_fit();
         
         for (k, v) in self.sets.drain() {
             let mut tags = v.tags;
@@ -192,7 +195,6 @@ impl Aggregator {
                 tags,
             ));
         }
-        self.sets.shrink_to_fit();
         
         for (k, v) in self.histograms.drain() {
             metrics.extend(PERCENTILES.iter().cloned().map(|p| {
@@ -204,7 +206,6 @@ impl Aggregator {
                 )
             }));
         }
-        self.histograms.shrink_to_fit();
 
         metrics
     }

--- a/src/aggregations/mod.rs
+++ b/src/aggregations/mod.rs
@@ -1,4 +1,4 @@
-mod buffer;
+pub mod buffer;
 mod container;
 mod regex;
 mod systemdetails;

--- a/src/aggregations/regex.rs
+++ b/src/aggregations/regex.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use ::actix::prelude::*;
-use futures::Future;
+use actix::prelude::*;
+use rayon::prelude::*;
 use regex::Regex as RegexMatcher;
 
 use crate::backends::Message;
 use crate::metrics::Measurement;
 
-pub struct Regex(HashMap<String, (RegexMatcher, String)>, Recipient<Message>);
+type Rules = Arc<HashMap<String, (RegexMatcher, String)>>;
+pub struct Regex(Rules, Recipient<Message>);
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RegexPattern {
     pub regex: String,
@@ -30,19 +32,10 @@ impl Regex {
                     p.key,
                     (RegexMatcher::new(&p.regex).unwrap(), p.replace_with),
                 )
-            }).collect();
+            })
+            .collect();
 
-        Regex(rules, upstream).start().recipient()
-    }
-
-    fn filter_tags(&self, msg: &mut Measurement) {
-        for (key, value) in msg.tags.iter_mut() {
-            if let Some((regex, replace)) = self.0.get(key) {
-                if regex.is_match(value) {
-                    *value = replace.clone();
-                }
-            }
-        }
+        Regex(Arc::new(rules), upstream).start().recipient()
     }
 }
 
@@ -50,17 +43,28 @@ impl Actor for Regex {
     type Context = Context<Self>;
 }
 
+fn filter_tags(msg: &mut Measurement, rules: Rules) {
+    for (key, value) in msg.tags.iter_mut() {
+        if let Some((regex, replace)) = rules.get(key) {
+            if regex.is_match(value) {
+                *value = replace.clone();
+            }
+        }
+    }
+}
+
 impl Handler<Message> for Regex {
     type Result = ();
 
     fn handle(&mut self, mut msg: Message, _ctx: &mut Context<Self>) -> Self::Result {
+        let rules = self.0.clone();
         match msg {
-            Message::List(ref mut ms) => for mut m in ms {
-                self.filter_tags(&mut m);
-            },
-            Message::Single(ref mut m) => self.filter_tags(m),
+            Message::List(ref mut ms) => ms
+                .par_iter_mut()
+                .for_each(move |m| filter_tags(m, rules.clone())),
+            Message::Single(ref mut m) => filter_tags(m, rules),
         }
 
-        ::actix::spawn(self.1.send(msg).map_err(|_| ()));
+        self.1.do_send(msg).unwrap();
     }
 }

--- a/src/grains/ebpf.rs
+++ b/src/grains/ebpf.rs
@@ -1,6 +1,7 @@
 use crate::backends::Message;
+use crate::grains::SendToManyRecipients;
 use crate::grains::ebpf_io::{
-    MessageStream, MessageStreams, PerfMessageStream, SocketMessageStream,
+    MessageStream, MessageStreams, PerfMessageStream, SocketMessageStream
 };
 
 use redbpf::{cpus, Module, PerfMap, XdpFlags, Result};
@@ -181,9 +182,7 @@ impl Actor for EBPFActor {
 impl StreamHandler<Vec<Message>, io::Error> for EBPFActor {
     fn handle(&mut self, mut messages: Vec<Message>, _ctx: &mut Context<Self>) {
         for message in messages.drain(..) {
-            for recipient in &self.recipients {
-                recipient.do_send(message.clone()).unwrap();
-            }
+            self.recipients.do_send(message);
         }
     }
 

--- a/src/grains/osquery.rs
+++ b/src/grains/osquery.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use actix::{Actor, AsyncContext, Context, Recipient};
 
+use crate::grains::SendToManyRecipients;
 use crate::backends::Message;
 use crate::metrics::{kind, Measurement, Tags, Unit};
 
@@ -147,9 +148,7 @@ impl Osquery {
             .map_err(|e| OsqueryError::IOError(e))?;
         let measurements = self.process_query_result(query, &output)?;
         let message = Message::List(measurements);
-        for recipient in &self.recipients {
-            recipient.do_send(message.clone()).unwrap();
-        }
+        self.recipients.do_send(message);
 
         Ok(())
     }

--- a/src/grains/statsd.rs
+++ b/src/grains/statsd.rs
@@ -8,6 +8,7 @@ use bytes::BytesMut;
 use tokio::codec;
 use tokio_udp::{UdpFramed, UdpSocket};
 
+use crate::grains::SendToManyRecipients;
 use crate::backends::Message;
 use crate::metrics::{kind, Measurement, Tags, Unit};
 
@@ -178,9 +179,7 @@ impl StreamHandler<(Vec<Metric>, SocketAddr), DecoderError> for Statsd {
         _ctx: &mut Context<Statsd>,
     ) {
         let message: Message = metrics.into();
-        for recipient in &self.recipients {
-            recipient.do_send(message.clone()).unwrap();
-        }
+        self.recipients.do_send(message);
     }
 
     fn error(&mut self, err: DecoderError, _ctx: &mut Self::Context) -> Running {

--- a/src/grains/test.rs
+++ b/src/grains/test.rs
@@ -1,5 +1,6 @@
 use actix::{Actor, AsyncContext, Context, Recipient, StreamHandler};
 use futures::{Async, Poll, Stream};
+use std::{time, thread};
 
 use crate::backends::Message;
 use crate::metrics::{kind, timestamp_now, Measurement, Tags, Unit};
@@ -19,7 +20,7 @@ impl Actor for TestProbe {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        info!("debug probe started");
+        info!("debug probe started {:?}", std::thread::current().id());
         let unit = Unit::try_from_str(
             &self.config.measurement_type,
             self.config.measurement.parse().unwrap_or_default(),
@@ -31,6 +32,7 @@ impl Actor for TestProbe {
             unit,
             kind,
             self.config.tags.clone(),
+            self.config.message_len
         ));
     }
 
@@ -52,15 +54,17 @@ pub struct MeasurementStream {
     unit: Unit,
     kind: kind::Kind,
     tags: Vec<Tag>,
+    message_len: usize
 }
 
 impl MeasurementStream {
-    fn new(name: String, unit: Unit, kind: kind::Kind, tags: Vec<Tag>) -> Self {
+    fn new(name: String, unit: Unit, kind: kind::Kind, tags: Vec<Tag>, message_len: usize) -> Self {
         MeasurementStream {
             name,
             unit,
             kind,
             tags,
+            message_len
         }
     }
 }
@@ -70,26 +74,32 @@ impl Stream for MeasurementStream {
     type Error = ();
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        let mut tags = Tags::new();
-        for (key, value) in &self.tags {
-            let value = match value.as_str() {
-                "$TS" => format!("{}", timestamp_now()),
-                _ => value.clone(),
-            };
-            tags.insert(key.clone(), value);
-        }
-        let measurement = Measurement::new(
-            self.kind,
-            self.name.clone(),
-            self.unit.clone(),
-            tags,
-        );
-        let message = Message::Single(measurement);
+        let measurements = (0..self.message_len).map(|_| {
+            let mut tags = Tags::new();
+            for (key, value) in &self.tags {
+                let value = match value.as_str() {
+                    "$TS" => format!("{}", timestamp_now()),
+                    _ => value.clone(),
+                };
+                tags.insert(key.clone(), value);
+            }
+            Measurement::new(
+                self.kind,
+                self.name.clone(),
+                self.unit.clone(),
+                tags,
+            )
+        }).collect();
+        let message = Message::List(measurements);
         Ok(Async::Ready(Some(message)))
     }
 }
 
 pub type Tag = (String, String);
+
+fn default_message_len() -> usize {
+    5000
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TestProbeConfig {
@@ -98,4 +108,6 @@ pub struct TestProbeConfig {
     measurement_type: String,
     aggregation_type: Option<String>,
     tags: Vec<Tag>,
+    #[serde(default = "default_message_len")]
+    message_len: usize
 }

--- a/src/grains/test.rs
+++ b/src/grains/test.rs
@@ -2,6 +2,7 @@ use actix::{Actor, AsyncContext, Context, Recipient, StreamHandler};
 use futures::{Async, Poll, Stream};
 use std::{time, thread};
 
+use crate::grains::SendToManyRecipients;
 use crate::backends::Message;
 use crate::metrics::{kind, timestamp_now, Measurement, Tags, Unit};
 
@@ -43,9 +44,7 @@ impl Actor for TestProbe {
 
 impl StreamHandler<Message, ()> for TestProbe {
     fn handle(&mut self, message: Message, _ctx: &mut Context<TestProbe>) {
-        for recipient in &self.recipients {
-            recipient.do_send(message.clone()).unwrap();
-        }
+        self.recipients.do_send(message);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,19 @@
+#![deny(clippy::all)]
+
+#[macro_use]
+extern crate actix;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate log;
+pub mod aggregations;
+pub mod backends;
+pub mod config;
+pub mod grains;
+pub mod metrics;
+#[cfg(feature = "capnp-encoding")]
+mod ingraind_capnp {
+    #![allow(clippy::all)]
+    #![allow(dead_code)]
+    include!(concat!(env!("OUT_DIR"), "/schema/ingraind_capnp.rs"));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,11 @@
 #![deny(clippy::all)]
 
-#[macro_use]
-extern crate actix;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate log;
-
 use std::collections::HashMap;
 use std::env;
 use std::fs;
 
-mod aggregations;
-mod backends;
-mod config;
-mod grains;
-mod metrics;
-
 use actix::Recipient;
-use backends::Message;
+use ingraind::{backends::Message, config};
 
 #[cfg(feature = "capnp-encoding")]
 mod ingraind_capnp {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -100,7 +100,7 @@ pub enum Unit {
     Str(String)
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum UnitType {
     Byte,
     Count,


### PR DESCRIPTION
This PR fixes a number of performance problems, here's the highlights:

- When overloaded with metrics, the `Buffer` actor used to stop flushing out metrics, causing memory usage to grow indefinitely. This is now fixed by https://github.com/redsift/ingraind/commit/8241b23a6f5a2553f83b549b47791bf01ddb8b8f
- The `Buffer` actor now uses `rayon` to compute output metrics. I added a criterion benchmark that shows that `flush` now takes roughly 1/5 of the time it used to take before.
- I made all the other aggregators use `rayon` too. 
- When using only one pipeline, grains now don't clone their output metrics anymore.

Finally, this PR includes a change that adds a `measurements_per_second` key to the test grain, so that it's easier to test deterministic loads.