### PR TITLE
Exec Command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,6 +351,10 @@ workflows:
     jobs:
       - terraform_arm:
           name: 'terraform - ubuntu/arm64'
+          filters:
+            branches:
+              only:
+                - master
 
       - terraform:
           name: 'terraform - ubuntu 18.04'

--- a/config.toml.example
+++ b/config.toml.example
@@ -54,7 +54,7 @@ type = "Network"
 pipelines = ["console"]
 [probe.config]
 type = "DNS"
-interace = "eth0"
+interface = "eth0"
 
 # The TLS grain reports TLS ClientHello and ServerHello packets.
 
@@ -64,7 +64,7 @@ interace = "eth0"
 pipelines = ["console"]
 [probe.config]
 type = "TLS"
-interace = "eth0"
+interface = "eth0"
 
 # The Syscall grain allows tracking the frequency of specific system calls, system-wide.
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -176,10 +176,15 @@ type = "AddSystemDetails"
 # arguments for every event hitting the pipeline.
 #
 # Using the `{ tag_name }` syntax, the value of a tag can be substituted 
+#
+# If the `only_if` block is supplied, the ALL of the listed conditions
+# need to match to execute the command (AND relationship)
 [[pipeline.s3.steps]]
 type = "Exec"
-command = "kill"
-arguments = ["-9", "{ process_id }"]
+arguments = ["kill", "-9", "{ process_id }"]
+only_if = [
+  { key = "some_key", regex = "prefix.*" }
+]
 
 # The Whitelist filter will only preserve tags with the listed keys for a metric
 # record.

--- a/config.toml.example
+++ b/config.toml.example
@@ -172,6 +172,15 @@ backend = "S3"
 [[pipeline.s3.steps]]
 type = "AddSystemDetails"
 
+# The Exec aggregator will execute a command with the specified
+# arguments for every event hitting the pipeline.
+#
+# Using the `{ tag_name }` syntax, the value of a tag can be substituted 
+[[pipeline.s3.steps]]
+type = "Exec"
+command = "kill"
+arguments = ["-9", "{ process_id }"]
+
 # The Whitelist filter will only preserve tags with the listed keys for a metric
 # record.
 [[pipeline.s3.steps]]

--- a/src/aggregations/exec.rs
+++ b/src/aggregations/exec.rs
@@ -1,0 +1,64 @@
+use std::process::Command;
+use std::sync::Arc;
+
+use actix::prelude::*;
+use rayon::prelude::*;
+
+use crate::backends::Message;
+use crate::metrics::Measurement;
+
+pub struct Exec(ExecConfig, Recipient<Message>);
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ExecConfig {
+    pub command: String,
+    pub arguments: Vec<String>,
+}
+
+impl Exec {
+    pub fn launch(config: ExecConfig, upstream: Recipient<Message>) -> Recipient<Message> {
+        Exec(config, upstream).start().recipient()
+    }
+}
+
+impl Actor for Exec {
+    type Context = Context<Self>;
+}
+
+impl Handler<Message> for Exec {
+    type Result = ();
+
+    fn handle(&mut self, mut msg: Message, _ctx: &mut Context<Self>) -> Self::Result {
+        let rules = &self.0;
+        match msg {
+            Message::List(ref mut ms) => ms.par_iter_mut().for_each(move |m| run_command(rules, m)),
+            Message::Single(ref mut m) => run_command(rules, m),
+        }
+
+        self.1.do_send(msg).unwrap();
+    }
+}
+
+fn get_tag(msg: &Measurement, tag: &str) -> Option<String> {
+    for (key, value) in msg.tags.iter() {
+        if key == tag {
+            return Some(value.to_string());
+        }
+    }
+
+    None
+}
+
+fn run_command(conf: &ExecConfig, msg: &Measurement) {
+    let args = conf.arguments.iter().map(|a| {
+        let mut chars = a.chars();
+        if chars.nth(0) == Some('{') && chars.last() == Some('}') {
+            let t = get_tag(msg, a[1..a.len() - 1].trim());
+            if t.is_some() {
+                return t.unwrap();
+            }
+        }
+        a.to_string()
+    });
+
+    Command::new(&conf.command).args(args).spawn().expect("Failed to run command!");
+}

--- a/src/aggregations/mod.rs
+++ b/src/aggregations/mod.rs
@@ -3,8 +3,10 @@ mod container;
 mod regex;
 mod systemdetails;
 mod whitelist;
+mod exec;
 
 pub use self::buffer::*;
+pub use self::exec::*;
 pub use self::container::*;
 pub use self::regex::*;
 pub use self::systemdetails::*;

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -37,7 +37,10 @@ impl Handler<Message> for S3 {
     type Result = ();
 
     fn handle(&mut self, msg: Message, _ctx: &mut Context<Self>) -> Self::Result {
-        let body = super::encoders::to_json(msg).into();
+        let body = match msg {
+	    Message::Single(m) => super::encoders::to_json(&vec![m]).into(),
+	    Message::List(ref ms) => super::encoders::to_json(ms).into(),
+	};
 
         ::actix::spawn(
             self.client

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,9 +71,10 @@ pub enum Backend {
 pub enum Aggregator {
     AddSystemDetails,
     Buffer(BufferConfig),
+    Container(ContainerConfig),
+    Exec(ExecConfig),
     Regex(RegexConfig),
     Whitelist(WhitelistConfig),
-    Container(ContainerConfig),
 }
 
 impl Aggregator {
@@ -81,9 +82,10 @@ impl Aggregator {
         match self {
             Aggregator::AddSystemDetails => AddSystemDetails::launch(upstream),
             Aggregator::Buffer(config) => Buffer::launch(config, upstream),
+            Aggregator::Container(config) => Container::launch(config, upstream),
+            Aggregator::Exec(config) => Exec::launch(config, upstream),
             Aggregator::Regex(config) => Regex::launch(config, upstream),
             Aggregator::Whitelist(config) => Whitelist::launch(config, upstream),
-            Aggregator::Container(config) => Container::launch(config, upstream),
         }
     }
 }


### PR DESCRIPTION
Add a way to execute a command based on events from the pipeline.

This is a rough version, and in order to use this successfully, we're going to need to flesh out some filtering in the pipeline, because there are 2 shortcomings:

 1. The command is run for every event that reaches the aggregator
 2. The command is run synchronously, possibly creating backpressure on huge loads

Maybe we should add a new tag based on the action taken.