### PR TITLE
Add Ansible roles for deploying on Yum/Apt-based systems

### DIFF
--- a/ansible/roles/ingraind/handlers/main.yml
+++ b/ansible/roles/ingraind/handlers/main.yml
@@ -1,0 +1,6 @@
+- name: restart ingraind
+  systemd: 
+    name: ingraind.service
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/ansible/roles/ingraind/tasks/main.yml
+++ b/ansible/roles/ingraind/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- assert:
+    that:
+    - "ingraind_circleci_url is defined"
+    - "ingraind_http_api_key is defined"
+    - "ingraind_http_uri is defined"
+    - "ingraind_circleci_sha256 is defined"
+
+- name: Pull InGRAINd
+  get_url:
+    dest: "/usr/local/bin/ingraind"
+    url: "{{ ingraind_circleci_url }}"
+    checksum: "{{ ingraind_circleci_sha256 }}"
+    mode: 0755
+  notify:
+  - restart ingraind
+
+- name: Install Osquery
+  command: |
+    curl -L https://pkg.osquery.io/rpm/GPG | sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-osquery
+    yum-config-manager --add-repo https://pkg.osquery.io/rpm/osquery-s3-rpm.repo
+    yum-config-manager --enable osquery-s3-rpm
+    yum install osquery
+  ignore_errors: yes
+  when: ansible_facts['distribution'] in ['CentOS', 'Red Hat Enterprise Linux']
+
+- name: Install Osquery
+  command: |
+    export OSQUERY_KEY=1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $OSQUERY_KEY
+    add-apt-repository 'deb [arch=amd64] https://pkg.osquery.io/deb deb main'
+    apt-get update
+    apt-get install osquery
+  ignore_errors: yes
+  when: ansible_facts['distribution'] in ['Debian', 'Ubuntu']
+
+- name: Configure InGRAINd
+  file:
+    path: /etc/ingraind
+    state: directory
+    mode: 0755
+
+- template: src="{{ item }}.j2" dest="/{{ item }}"
+  loop:
+  - etc/ingraind/ingraind.toml
+  - etc/systemd/system/ingraind.service
+  notify:
+  - restart ingraind

--- a/ansible/roles/ingraind/templates/etc/ingraind/ingraind.toml.j2
+++ b/ansible/roles/ingraind/templates/etc/ingraind/ingraind.toml.j2
@@ -1,0 +1,74 @@
+[log]
+type = "EnvLogger"
+log_level = "ERROR"
+
+[[probe]]
+pipelines = ["prod"]
+[probe.config]
+type = "Files"
+monitor_dirs = ["/"]
+
+[[probe]]
+pipelines = ["prod"]
+[probe.config]
+type = "Network"
+
+[[probe]]
+pipelines = ["prod"]
+[probe.config]
+type = "DNS"
+interface = "eth0"
+
+[[probe]]
+pipelines = ["prod"]
+[probe.config]
+type = "TLS"
+interface = "eth0"
+
+[[probe]]
+pipelines = ["prod"]
+[probe.config]
+type = "Osquery"
+interval_ms = 10000
+
+[[probe.config.queries]]
+query = "SELECT user_time, name as process_str, pid as process_id from processes"
+name = "process_user_time"
+measurement = "user_time"
+measurement_type = "count"
+run_at_start = true
+
+[[probe.config.queries]]
+query = "SELECT system_time, name as process_str, pid as process_id from processes"
+name = "process_system_time"
+measurement = "system_time"
+measurement_type = "count"
+run_at_start = true
+
+[[probe.config.queries]]
+query = "SELECT resident_size, total_size, name as process_str, pid as process_id from processes"
+name = "process_rss"
+measurement = "resident_size"
+measurement_type = "count"
+run_at_start = true
+
+[pipeline.prod.config]
+backend = "HTTP"
+encoding = "JSON"
+uri = "{{ ingraind_http_uri }}"
+headers = { authorization = "API-Key {{ ingraind_http_api_key }}", "redsift-account" = "header" }
+
+[[pipeline.prod.steps]]
+type = "Container"
+
+[[pipeline.prod.steps]]
+type = "AddSystemDetails"
+
+[[pipeline.prod.steps]]
+type = "Regex"
+patterns = [{ key = "process_str", regex = "conn\\d+", replace_with = "docker_proxy"}]
+
+[[pipeline.prod.steps]]
+type = "Buffer"
+enable_histograms = false
+interval_s = 10

--- a/ansible/roles/ingraind/templates/etc/systemd/system/ingraind.service.j2
+++ b/ansible/roles/ingraind/templates/etc/systemd/system/ingraind.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=InGRAINd data collection agent
+Requires=network.service
+
+[Service]
+ExecStart=/usr/local/bin/ingraind /etc/ingraind/ingraind.toml

--- a/ansible/roles/ingraind/vars/main.yml
+++ b/ansible/roles/ingraind/vars/main.yml
@@ -1,0 +1,5 @@
+---
+ingraind_circleci_url: https://930-130035428-gh.circle-artifacts.com/0/ingraind-binaries/ingraind
+ingraind_circleci_sha256: sha256:413ceda9ce8320867aa90ecb8aa220d3b4aadd82ea7d6ba4e05e6e7f9042e0dd
+ingraind_http_api_key: example
+ingraind_http_uri: https://uri/to/path


### PR DESCRIPTION
Currently RHEL, CentOS, Debian, and Ubuntu are recognised.

The role also deploys [OSQuery](https://osquery.io) along with InGRAINd.