### PR TITLE
probes: improve signature

### DIFF
--- a/ingraind-probes/src/dns/main.rs
+++ b/ingraind-probes/src/dns/main.rs
@@ -18,7 +18,7 @@ program!(0xFFFFFFFE, "GPL");
 static mut events: PerfMap<Event> = PerfMap::with_max_entries(1024);
 
 #[xdp("dns_queries")]
-pub extern "C" fn probe(ctx: XdpContext) -> XdpAction {
+pub fn probe(ctx: XdpContext) -> XdpAction {
     let (ip, transport) = match (ctx.ip(), ctx.transport()) {
         (Some(i), Some(t)) => (unsafe { *i }, t),
         _ => return XdpAction::Pass,

--- a/ingraind-probes/src/file/main.rs
+++ b/ingraind-probes/src/file/main.rs
@@ -37,37 +37,31 @@ static mut files: HashMap<u64, *const file> = HashMap::with_max_entries(10240);
 static mut rw: PerfMap<FileAccess> = PerfMap::with_max_entries(1024);
 
 #[kprobe("vfs_read")]
-pub fn trace_read_entry(regs: Registers) -> i32 {
+pub fn trace_read_entry(regs: Registers) {
     let tid = bpf_get_current_pid_tgid();
     unsafe {
         let f = regs.parm1() as *const file;
         files.set(tid, f);
     }
-
-    0
 }
 
 #[kretprobe("vfs_read")]
-pub fn trace_read_exit(regs: Registers) -> i32 {
+pub fn trace_read_exit(regs: Registers) {
     track_file_access(regs, AccessType::Read);
-    0
 }
 
 #[kprobe("vfs_write")]
-pub fn trace_write_entry(regs: Registers) -> i32 {
+pub fn trace_write_entry(regs: Registers) {
     let tid = bpf_get_current_pid_tgid();
     unsafe {
         let f = regs.parm1() as *const file;
         files.set(tid, f);
     }
-
-    0
 }
 
 #[kretprobe("vfs_write")]
-pub fn trace_write_exit(regs: Registers) -> i32 {
+pub fn trace_write_exit(regs: Registers) {
     track_file_access(regs, AccessType::Write);
-    0
 }
 
 #[inline]
@@ -159,13 +153,13 @@ fn dentry_to_path(mut dentry: *mut dentry) -> Option<PathList> {
 
     match policy {
         Some(InodePolicy::Record) => Some(path_list),
-        _ => None
+        _ => None,
     }
 }
 
 enum InodePolicy {
     Record,
-    Ignore
+    Ignore,
 }
 
 #[inline]
@@ -175,6 +169,6 @@ fn policy_for_inode(inode: u64) -> Option<InodePolicy> {
     match unsafe { actionlist.get(inode) } {
         Some(0) => Some(Ignore),
         Some(1) => Some(Record),
-        _ => None
+        _ => None,
     }
 }

--- a/ingraind-probes/src/file/main.rs
+++ b/ingraind-probes/src/file/main.rs
@@ -37,7 +37,7 @@ static mut files: HashMap<u64, *const file> = HashMap::with_max_entries(10240);
 static mut rw: PerfMap<FileAccess> = PerfMap::with_max_entries(1024);
 
 #[kprobe("vfs_read")]
-pub extern "C" fn trace_read_entry(regs: Registers) -> i32 {
+pub fn trace_read_entry(regs: Registers) -> i32 {
     let tid = bpf_get_current_pid_tgid();
     unsafe {
         let f = regs.parm1() as *const file;
@@ -48,13 +48,13 @@ pub extern "C" fn trace_read_entry(regs: Registers) -> i32 {
 }
 
 #[kretprobe("vfs_read")]
-pub extern "C" fn trace_read_exit(regs: Registers) -> i32 {
+pub fn trace_read_exit(regs: Registers) -> i32 {
     track_file_access(regs, AccessType::Read);
     0
 }
 
 #[kprobe("vfs_write")]
-pub extern "C" fn trace_write_entry(regs: Registers) -> i32 {
+pub fn trace_write_entry(regs: Registers) -> i32 {
     let tid = bpf_get_current_pid_tgid();
     unsafe {
         let f = regs.parm1() as *const file;
@@ -65,7 +65,7 @@ pub extern "C" fn trace_write_entry(regs: Registers) -> i32 {
 }
 
 #[kretprobe("vfs_write")]
-pub extern "C" fn trace_write_exit(regs: Registers) -> i32 {
+pub fn trace_write_exit(regs: Registers) -> i32 {
     track_file_access(regs, AccessType::Write);
     0
 }

--- a/ingraind-probes/src/network/main.rs
+++ b/ingraind-probes/src/network/main.rs
@@ -26,12 +26,12 @@ static mut ip_connections: PerfMap<Connection> = PerfMap::with_max_entries(1024)
 static mut ip_volumes: PerfMap<Message> = PerfMap::with_max_entries(1024);
 
 #[kprobe("tcp_v4_connect")]
-pub extern "C" fn connect_enter(regs: Registers) -> i32 {
+pub fn connect_enter(regs: Registers) -> i32 {
     store_socket(regs)
 }
 
 #[kretprobe("tcp_v4_connect")]
-pub extern "C" fn connect(regs: Registers) -> i32
+pub fn connect(regs: Registers) -> i32
 {
     match conn_details(regs) {
         Some(c) => unsafe {
@@ -43,32 +43,32 @@ pub extern "C" fn connect(regs: Registers) -> i32
 }
 
 #[kprobe("tcp_sendmsg")]
-pub extern "C" fn send_enter(regs: Registers) -> i32 {
+pub fn send_enter(regs: Registers) -> i32 {
     store_socket(regs)
 }
 
 #[kretprobe("tcp_sendmsg")]
-pub extern "C" fn send_exit(regs: Registers) -> i32 {
+pub fn send_exit(regs: Registers) -> i32 {
     trace_message(regs, Message::Send)
 }
 
 #[kprobe("tcp_recvmsg")]
-pub extern "C" fn recv_enter(regs: Registers) -> i32 {
+pub fn recv_enter(regs: Registers) -> i32 {
     store_socket(regs)
 }
 
 #[kretprobe("tcp_recvmsg")]
-pub extern "C" fn recv_exit(regs: Registers) -> i32 {
+pub fn recv_exit(regs: Registers) -> i32 {
     trace_message(regs, Message::Receive)
 }
 
 #[kprobe("udp_sendmsg")]
-pub extern "C" fn udp_send_enter(regs: Registers) -> i32 {
+pub fn udp_send_enter(regs: Registers) -> i32 {
     trace_message(regs, Message::Send)
 }
 
 #[kprobe("udp_rcv")]
-pub extern "C" fn udp_rcv_enter(regs: Registers) -> i32 {
+pub fn udp_rcv_enter(regs: Registers) -> i32 {
     trace_message(regs, Message::Receive)
 }
 

--- a/ingraind-probes/src/network/main.rs
+++ b/ingraind-probes/src/network/main.rs
@@ -26,15 +26,16 @@ static mut ip_connections: PerfMap<Connection> = PerfMap::with_max_entries(1024)
 static mut ip_volumes: PerfMap<Message> = PerfMap::with_max_entries(1024);
 
 #[kprobe("tcp_v4_connect")]
-pub extern "C" fn connect_enter(ctx: *mut c_void) -> i32 {
-    store_socket(ctx)
+pub extern "C" fn connect_enter(regs: Registers) -> i32 {
+    store_socket(regs)
 }
 
 #[kretprobe("tcp_v4_connect")]
-pub extern "C" fn connect(ctx: *mut c_void) -> i32 {
-    match conn_details(ctx) {
+pub extern "C" fn connect(regs: Registers) -> i32
+{
+    match conn_details(regs) {
         Some(c) => unsafe {
-            ip_connections.insert(ctx, c);
+            ip_connections.insert(regs.ctx, c);
             0
         },
         None => 0,
@@ -42,52 +43,50 @@ pub extern "C" fn connect(ctx: *mut c_void) -> i32 {
 }
 
 #[kprobe("tcp_sendmsg")]
-pub extern "C" fn send_enter(ctx: *mut c_void) -> i32 {
-    store_socket(ctx)
+pub extern "C" fn send_enter(regs: Registers) -> i32 {
+    store_socket(regs)
 }
 
 #[kretprobe("tcp_sendmsg")]
-pub extern "C" fn send_exit(ctx: *mut c_void) -> i32 {
-    trace_message(ctx, Message::Send)
+pub extern "C" fn send_exit(regs: Registers) -> i32 {
+    trace_message(regs, Message::Send)
 }
 
 #[kprobe("tcp_recvmsg")]
-pub extern "C" fn recv_enter(ctx: *mut c_void) -> i32 {
-    store_socket(ctx)
+pub extern "C" fn recv_enter(regs: Registers) -> i32 {
+    store_socket(regs)
 }
 
 #[kretprobe("tcp_recvmsg")]
-pub extern "C" fn recv_exit(ctx: *mut c_void) -> i32 {
-    trace_message(ctx, Message::Receive)
+pub extern "C" fn recv_exit(regs: Registers) -> i32 {
+    trace_message(regs, Message::Receive)
 }
 
 #[kprobe("udp_sendmsg")]
-pub extern "C" fn udp_send_enter(ctx: *mut c_void) -> i32 {
-    trace_message(ctx, Message::Send)
+pub extern "C" fn udp_send_enter(regs: Registers) -> i32 {
+    trace_message(regs, Message::Send)
 }
 
 #[kprobe("udp_rcv")]
-pub extern "C" fn udp_rcv_enter(ctx: *mut c_void) -> i32 {
-    trace_message(ctx, Message::Receive)
+pub extern "C" fn udp_rcv_enter(regs: Registers) -> i32 {
+    trace_message(regs, Message::Receive)
 }
 
 #[inline(always)]
-fn store_socket(ctx: *mut c_void) -> i32 {
-    let regs = Registers::from(ctx);
+fn store_socket(regs: Registers) -> i32 {
     unsafe { task_to_socket.set(bpf_get_current_pid_tgid(), regs.parm1() as *const sock) };
 
     0
 }
 
 #[inline(always)]
-fn trace_message(ctx: *mut c_void, direction: fn(Connection, u16) -> Message) -> i32 {
-    let regs = Registers::from(ctx);
+fn trace_message(regs: Registers, direction: fn(Connection, u16) -> Message) -> i32 {
     let len = regs.parm3() as u16;
-    let conn = conn_details(regs.parm1() as *mut c_void);
+    let conn = conn_details(regs);
 
     match conn {
         Some(c) => unsafe {
-            ip_volumes.insert(ctx, direction(c, len));
+            ip_volumes.insert(regs.ctx, direction(c, len));
             0
         },
         None => 0,
@@ -95,7 +94,7 @@ fn trace_message(ctx: *mut c_void, direction: fn(Connection, u16) -> Message) ->
 }
 
 #[inline(always)]
-pub fn conn_details(_ctx: *mut c_void) -> Option<Connection> {
+pub fn conn_details(_regs: Registers) -> Option<Connection> {
     let pid_tgid = bpf_get_current_pid_tgid();
     let socket = unsafe { match task_to_socket.get(pid_tgid) {
         Some(s) => &**s,

--- a/ingraind-probes/src/syscalls/main.rs
+++ b/ingraind-probes/src/syscalls/main.rs
@@ -3,12 +3,12 @@
 
 use cty::*;
 
+use ingraind_probes::syscalls::SyscallTracepoint;
+use redbpf_macros::{kprobe, map, program};
 use redbpf_probes::bindings::*;
 use redbpf_probes::helpers::*;
 use redbpf_probes::kprobe::Registers;
 use redbpf_probes::maps::*;
-use redbpf_macros::{map, program, kprobe};
-use ingraind_probes::syscalls::SyscallTracepoint;
 
 program!(0xFFFFFFFE, "GPL");
 
@@ -20,22 +20,22 @@ static mut host_pid: HashMap<u8, u64> = HashMap::with_max_entries(1024);
 
 #[kprobe("__x64_sys_clone")]
 pub fn syscall_enter(regs: Registers) {
-  let ignore_pid = unsafe { host_pid.get(1u8) };
-  let pid_tgid = bpf_get_current_pid_tgid();
-  if let Some(pid) = ignore_pid {
-    if *pid == pid_tgid >> 32 {
-      return;
+    let ignore_pid = unsafe { host_pid.get(1u8) };
+    let pid_tgid = bpf_get_current_pid_tgid();
+    if let Some(pid) = ignore_pid {
+        if *pid == pid_tgid >> 32 {
+            return;
+        }
     }
-  }
-  #[cfg(target_arch = "x86_64")]
-  let syscall_nr = unsafe { (*(regs.ctx as *const pt_regs)).ax };
-  #[cfg(target_arch = "aarch64")]
-  let syscall_nr = unsafe { (*(regs.ctx as *const user_pt_regs)).regs[1] };
+    #[cfg(target_arch = "x86_64")]
+    let syscall_nr = unsafe { (*(regs.ctx as *const pt_regs)).ax };
+    #[cfg(target_arch = "aarch64")]
+    let syscall_nr = unsafe { (*(regs.ctx as *const user_pt_regs)).regs[1] };
 
-  let data = SyscallTracepoint {
-    id: pid_tgid >> 32,
-    syscall_nr,
-    comm: bpf_get_current_comm(),
-  };
-  unsafe { syscall_event.insert(regs.ctx, data) };
+    let data = SyscallTracepoint {
+        id: pid_tgid >> 32,
+        syscall_nr,
+        comm: bpf_get_current_comm(),
+    };
+    unsafe { syscall_event.insert(regs.ctx, data) };
 }

--- a/ingraind-probes/src/syscalls/main.rs
+++ b/ingraind-probes/src/syscalls/main.rs
@@ -5,6 +5,7 @@ use cty::*;
 
 use redbpf_probes::bindings::*;
 use redbpf_probes::helpers::*;
+use redbpf_probes::kprobe::Registers;
 use redbpf_probes::maps::*;
 use redbpf_macros::{map, program, kprobe};
 use ingraind_probes::syscalls::SyscallTracepoint;
@@ -17,8 +18,8 @@ static mut syscall_event: PerfMap<SyscallTracepoint> = PerfMap::with_max_entries
 #[map("host_pid")]
 static mut host_pid: HashMap<u8, u64> = HashMap::with_max_entries(1024);
 
-#[kprobe("__arm64_sys_clone")]
-pub extern "C" fn syscall_enter(ctx: *mut c_void) -> i32 {
+#[kprobe("__x64_sys_clone")]
+pub extern "C" fn syscall_enter(regs: Registers) -> i32 {
   let ignore_pid = unsafe { host_pid.get(1u8) };
   let pid_tgid = bpf_get_current_pid_tgid();
   if let Some(pid) = ignore_pid {
@@ -27,16 +28,16 @@ pub extern "C" fn syscall_enter(ctx: *mut c_void) -> i32 {
     }
   }
   #[cfg(target_arch = "x86_64")]
-  let syscall_nr = unsafe { (*(ctx as *const pt_regs)).ax };
+  let syscall_nr = unsafe { (*(regs.ctx as *const pt_regs)).ax };
   #[cfg(target_arch = "aarch64")]
-  let syscall_nr = unsafe { (*(ctx as *const user_pt_regs)).regs[1] };
+  let syscall_nr = unsafe { (*(regs.ctx as *const user_pt_regs)).regs[1] };
 
   let data = SyscallTracepoint {
     id: pid_tgid >> 32,
     syscall_nr,
     comm: bpf_get_current_comm(),
   };
-  unsafe { syscall_event.insert(ctx, data) };
+  unsafe { syscall_event.insert(regs.ctx, data) };
 
   return 0;
 }

--- a/ingraind-probes/src/syscalls/main.rs
+++ b/ingraind-probes/src/syscalls/main.rs
@@ -19,12 +19,12 @@ static mut syscall_event: PerfMap<SyscallTracepoint> = PerfMap::with_max_entries
 static mut host_pid: HashMap<u8, u64> = HashMap::with_max_entries(1024);
 
 #[kprobe("__x64_sys_clone")]
-pub fn syscall_enter(regs: Registers) -> i32 {
+pub fn syscall_enter(regs: Registers) {
   let ignore_pid = unsafe { host_pid.get(1u8) };
   let pid_tgid = bpf_get_current_pid_tgid();
   if let Some(pid) = ignore_pid {
     if *pid == pid_tgid >> 32 {
-      return 0;
+      return;
     }
   }
   #[cfg(target_arch = "x86_64")]
@@ -38,6 +38,4 @@ pub fn syscall_enter(regs: Registers) -> i32 {
     comm: bpf_get_current_comm(),
   };
   unsafe { syscall_event.insert(regs.ctx, data) };
-
-  return 0;
 }

--- a/ingraind-probes/src/syscalls/main.rs
+++ b/ingraind-probes/src/syscalls/main.rs
@@ -19,7 +19,7 @@ static mut syscall_event: PerfMap<SyscallTracepoint> = PerfMap::with_max_entries
 static mut host_pid: HashMap<u8, u64> = HashMap::with_max_entries(1024);
 
 #[kprobe("__x64_sys_clone")]
-pub extern "C" fn syscall_enter(regs: Registers) -> i32 {
+pub fn syscall_enter(regs: Registers) -> i32 {
   let ignore_pid = unsafe { host_pid.get(1u8) };
   let pid_tgid = bpf_get_current_pid_tgid();
   if let Some(pid) = ignore_pid {

--- a/ingraind-probes/src/tls/main.rs
+++ b/ingraind-probes/src/tls/main.rs
@@ -11,7 +11,7 @@ use redbpf_probes::socket_filter::{SkBuff, SkBuffAction, SkBuffResult};
 program!(0xFFFFFFFE, "GPL");
 
 #[socket_filter("tls_handshake")]
-pub extern "C" fn tls_handshake(skb: SkBuff) -> SkBuffResult {
+pub fn tls_handshake(skb: SkBuff) -> SkBuffResult {
     let eth_len = mem::size_of::<ethhdr>();
     let mut eth_proto: u16 = skb.load(offset_of!(ethhdr, h_proto))?;
     let ip_proto: u8 = skb.load(eth_len + offset_of!(iphdr, protocol))?;


### PR DESCRIPTION
This PR changes kprobes to take `kprobe::Registers` as their first argument instead of `*mut c_void`. Additionally, it removes `extern "C"` from probe signatures as that hasn't been necessary for a while.

Requires https://github.com/redsift/redbpf/pull/38