### PR TITLE
Improved Kubernetes and Docker support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
             ./rustup.sh -y
             . /root/.cargo/env
             cat /root/.cargo/env >> $BASH_ENV
-            rustup default nightly
+            rustup default stable
             rustup target add x86_64-unknown-linux-musl
             rustup component add rustfmt
   cargo_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
       - run:
           name: Install deps
           command: |
-            yum install -y clang-9.0.0 llvm-9.0.0 llvm-libs-9.0.0 llvm-devel-9.0.0 llvm-static-9.0.0 capnproto kernel kernel-devel elfutils-libelf-devel ca-certificates
+            yum install -y clang-9.0.0 llvm-9.0.0 llvm-libs-9.0.0 llvm-devel-9.0.0 llvm-static-9.0.0 capnproto kernel kernel-devel elfutils-libelf-devel ca-certificates openssl-devel
 
       - install_rust
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
           name: Install deps
           command: |
             apt-get update
-            apt-get install -y build-essential bc kmod cpio libncurses5-dev
+            apt-get install -y build-essential bc kmod cpio libncurses5-dev gcc-8
 
       - run:
           name: Configure kernel tree
@@ -177,7 +177,7 @@ jobs:
             tar -xf kernel.tgz
             zcat /build/tests/gke/config-gke-4.14.138+.gz > .config
             make olddefconfig
-            make prepare
+            make prepare CC=gcc-8
             echo export KERNEL_SOURCE=/build/cos-kernel >> $BASH_ENV
             cd ..
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,27 +159,15 @@ jobs:
     working_directory: /build
     resource_class: large
     docker:
-      - image: ubuntu
+      - image: quay.io/redsift/ingraind-build:19.10
     steps:
       - checkout
-      - run:
-          name: Install some deps
-          command: |
-            apt-get update
-            apt-get install -y curl wget gnupg2 software-properties-common lsb-release
 
       - run:
-          name: Configure llvm 9 repo
-          command: |
-            curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-            add-apt-repository 'deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic-9  main'
-
-      - run:
-          name: Install more deps
+          name: Install deps
           command: |
             apt-get update
-            apt-get install -y build-essential bc kmod cpio flex cpio libncurses5-dev
-            apt-get install -y clang llvm llvm-9 musl-tools capnproto libelf-dev ca-certificates{,-java}
+            apt-get install -y build-essential bc kmod cpio libncurses5-dev
 
       - run:
           name: Configure kernel tree
@@ -192,8 +180,6 @@ jobs:
             make prepare
             echo export KERNEL_SOURCE=/build/cos-kernel >> $BASH_ENV
             cd ..
-
-      - install_rust
 
       - cargo_build:
           type: debug

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rayon = "1.2.1"
 dns-parser = "0.8"
 hdrhistogram = { version = "7.0", default-features = false }
 
-kube = { version = "0.32.1", default-features = false, features = ["rustls-tls"] }
+kube = "0.32.1"
 k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_14"] }
 
 bollard = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,13 @@ rayon = "1.2.1"
 
 dns-parser = "0.8"
 hdrhistogram = { version = "7.0", default-features = false }
+
+kube = { version = "0.32.1", default-features = false, features = ["rustls-tls"] }
+k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_14"] }
+
+bollard = "0.4"
+chrono = "0.4"
+
 ingraind-probes = { path = "ingraind-probes" }
 
 [dependencies.hyper]

--- a/config.toml.example
+++ b/config.toml.example
@@ -206,8 +206,13 @@ patterns = [
 
 # The Container filter will parse the Docker container ID from the
 # `/proc/<pid>/cgroup` file, and add a `docker_id` tag to the measurement.
+#
+# Supports an optional `system` key. When set to `Kubernetes`, it will add the
+# `kubernetes_namespace` and `kubernetes_pod_name` tags. When set to `Docker`
+# it will add the `docker_name` tag.
 [[pipeline.s3.steps]]
 type = "Container"
+system = "Kubernetes"
 
 # The Buffer aggregation will gather data for `interval_` seconds, and releases
 # it to the next step only after.

--- a/deploy/kubernetes/config.yaml
+++ b/deploy/kubernetes/config.yaml
@@ -70,6 +70,10 @@ data:
     type = "AddSystemDetails"
 
     [[pipeline.staging.steps]]
+    type = "Container"
+    system = "Kubernetes"
+
+    [[pipeline.staging.steps]]
     type = "Regex"
     patterns = [{ key = "process_str", regex = "conn\\d+", replace_with = "docker_proxy"}]
 

--- a/deploy/kubernetes/ingraind.yaml
+++ b/deploy/kubernetes/ingraind.yaml
@@ -17,7 +17,7 @@ spec:
       hostNetwork: true
       hostPID: true
       containers:
-      - image: quay.io/redsift/ingraind:latest
+      - image: quay.io/redsift/ingraind:latest-gke
         name: ingraind
         terminationMessagePath: /dev/termination-log
         env:

--- a/src/config.rs
+++ b/src/config.rs
@@ -206,6 +206,7 @@ use_tags = true
 
 [[pipeline.statsd.steps]]
 type = "Container"
+system = "Kubernetes"
 
 [[pipeline.statsd.steps]]
 type = "Whitelist"

--- a/tests/gke/config.yaml
+++ b/tests/gke/config.yaml
@@ -67,6 +67,10 @@ data:
     backend = "Console"
 
     [[pipeline.staging.steps]]
+    type = "Container"
+    system = "Kubernetes"
+
+    [[pipeline.staging.steps]]
     type = "AddSystemDetails"
 
     [[pipeline.staging.steps]]


### PR DESCRIPTION
This PR reworks the container aggregator. It adds an optional `system` key that when set to `Kubernetes` will add the `kubernetes_namespace` and `kubernetes_pod_name` tags, when set to `Docker` will add the `docker_name` tag.