### PR TITLE
Force unrolling loops in the file probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,7 @@ dependencies = [
  "memoffset",
  "redbpf-macros",
  "redbpf-probes",
+ "unroll",
 ]
 
 [[package]]
@@ -3270,6 +3271,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
+]
+
+[[package]]
+name = "unroll"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad948c1cb799b1a70f836077721a92a35ac177d4daddf4c20a633786d4cf618"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/ingraind-probes/Cargo.lock
+++ b/ingraind-probes/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "memoffset",
  "redbpf-macros",
  "redbpf-probes",
+ "unroll",
 ]
 
 [[package]]
@@ -530,6 +531,16 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unroll"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad948c1cb799b1a70f836077721a92a35ac177d4daddf4c20a633786d4cf618"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "vec_map"

--- a/ingraind-probes/Cargo.toml
+++ b/ingraind-probes/Cargo.toml
@@ -8,6 +8,7 @@ cty = "0.2"
 memoffset = "0.5.6"
 redbpf-macros = "^1.2"
 redbpf-probes = "^1.2"
+unroll = "0.1"
 
 [features]
 default = []

--- a/ingraind-probes/src/file/main.rs
+++ b/ingraind-probes/src/file/main.rs
@@ -1,9 +1,10 @@
 #![no_std]
 #![no_main]
-use redbpf_probes::kprobe::prelude::*;
 use ingraind_probes::file::{
     Access, FileAccess, PathList, PathSegment, PATH_LIST_LEN, PATH_SEGMENT_LEN,
 };
+use redbpf_probes::kprobe::prelude::*;
+use unroll::unroll_for_loops;
 
 enum AccessType {
     Read,
@@ -102,6 +103,7 @@ fn do_track_file_access(regs: Registers, access_type: AccessType) -> Option<()> 
 }
 
 #[inline]
+#[unroll_for_loops]
 fn dentry_to_path(mut dentry: *mut dentry, path_list: &mut PathList) -> Option<InodePolicy> {
     if dentry.is_null() {
         return None;


### PR DESCRIPTION
The latest migration to LLVM11 of redbpf seems to have broken the for loop unrolling that we use there.
Until we have a long-term solution, the [`unroll`](https://crates.io/crate/unroll) is a good solution to force unrolling a for loop on the language level.

This patch allows loading the `File` probe on 4.X kernels again.