### PR TITLE
Add support for archived El7 kernels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,52 @@ jobs:
           paths:
             - "target"
 
+  build_for_archive_kernel:
+    parameters:
+      kernel_version:
+        type: string
+      kernel_pkg:
+        type: string
+        default: kernel-ml
+      distro:
+        type: string
+        default: el7
+
+    working_directory: /build
+    resource_class: large
+    docker:
+      - image: quay.io/redsift/ingraind-build:fedora
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /build
+
+      - run:
+          name: Set up kernel for environment
+          command: |
+            yum install -y s3cmd
+            pkg=<< parameters.kernel_pkg >>-devel-<< parameters.kernel_version >>.rpm
+            s3cmd get s3://redsift-ops/kernels/<< parameters.distro >>/$pkg $pkg
+            rpm --nodeps -i --force $pkg
+            echo KERNEL_SOURCE=/usr/src/kernels/$(ls /usr/src/kernels |head -n1) >> $BASH_ENV
+
+      - cargo_build:
+          type: release
+          flags: --target=x86_64-unknown-linux-musl
+          binary: target/x86_64-unknown-linux-musl/release/ingraind
+
+      - run:
+          name: Upload artifact
+          command: |
+            k_pkg=<< parameters.kernel_version >>
+            binary=ingraind-${CIRCLE_SHA1:0:7}-${k_pkg#*-*-}
+            mv target/x86_64-unknown-linux-musl/release/ingraind $binary
+            echo $RSIGN_SK |sed "s/|/\n/g" >/tmp/rsign_sk
+            rsign sign -s /tmp/rsign_sk $binary
+
+            s3cmd put --acl-public --guess-mime-type $binary s3://redsift-ops/ingrain/$binary
+            s3cmd put --acl-public --guess-mime-type $binary.minisig s3://redsift-ops/ingrain/$binary.minisig
+
 workflows:
   version: 2.1
   build:
@@ -422,3 +468,12 @@ workflows:
           binary: "target/release/ingraind"
           requires:
             - gke-4.19
+
+  build_for_el7:
+    jobs:
+      - build_for_archive_kernel:
+          context: org-global
+          kernel_version: 5.6.4-1.el7.elrepo.x86_64
+      - build_for_archive_kernel:
+          context: org-global
+          kernel_version: 5.3.8-1.el7.elrepo.x86_64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ jobs:
             pkg=<< parameters.kernel_pkg >>-devel-<< parameters.kernel_version >>.rpm
             s3cmd get s3://redsift-ops/kernels/<< parameters.distro >>/$pkg $pkg
             rpm --nodeps -i --force $pkg
-            echo KERNEL_SOURCE=/usr/src/kernels/$(ls /usr/src/kernels |head -n1) >> $BASH_ENV
+            echo export KERNEL_SOURCE=/usr/src/kernels/$(rpm -qa kernel-devel |cut -d- -f3-)/ |tee $BASH_ENV
 
       - cargo_build:
           type: release


### PR DESCRIPTION
This PR makes it easier to build bare binaries for specific kernel versions in Elrepo7 for CentOS 7. We maintain our own repository of these kernels.